### PR TITLE
Generalized add_risk_meters script

### DIFF
--- a/add_risk_meters/add_risk_meters.rb
+++ b/add_risk_meters/add_risk_meters.rb
@@ -9,10 +9,8 @@ require 'csv'
 
 
 #Variables we'll need later
-@post_url = 'https://api.kennasecurity.com/asset_groups?historical=false'
+@post_url = 'https://api.kennasecurity.com/asset_groups?'
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token }
-
-fix_string = "fix_title_keyword%3A%28Adobe+OR+Java+OR+JBoss+OR+Apache+OR+JRE+OR+JDK+OR+Oracle+OR+JRockit+OR+IIS+OR+Tomcat+OR+%28Microsoft+AND+SQL+AND+Server%29+OR+Cygwin+OR+WebSphere+OR+PHP+OR+%28Computer+AND+Associates%29+OR+DB2+OR+Wireshark+OR+Firefox+OR+WebLogic+OR+Chrome+OR+SharePoint+OR+Silverlight+OR+%28Visual+AND+Basic%29+OR+Symantec+OR+%28Microsoft+AND+XML+AND+Editor%29+OR+Intel+OR+NetBIOS+OR+FTP+OR+SNMP+OR+SSL+OR+TLS+OR+IPMI+OR+DRAC%29+AND+-fix_title_keyword%3A%28Database+OR+jmx%29+AND-tag%3AAG_CMDB_Export_Mainframe_PROD"
 
 num_lines = CSV.read(@csv_file).length
 puts "Found #{num_lines} lines."
@@ -21,18 +19,19 @@ puts "Found #{num_lines} lines."
 CSV.foreach(@csv_file, :headers => true){|row|
   # "Reading line #{$.}... "
   current_line = $.
-  app_name = nil
+  risk_meter_name = nil
+  query_string = nil
 
-  app_name = row[0]
-
+  risk_meter_name = row[0]
+  query_string = row[1]
 
   json_data = {
       "asset_group" =>
         {
-          "name" => "APP: #{app_name}: Actual Risk Score",
+          "name" => "#{risk_meter_name}",
           "query" => 
-            {"status" => ["active"],
-             "tags" => ["#{app_name}"]
+            {
+              "q" => "#{query_string}"
             }
         }
     }
@@ -53,86 +52,6 @@ CSV.foreach(@csv_file, :headers => true){|row|
 
           end
 
-
-    json_data = {
-      "asset_group" =>
-        {
-          "name" => "APP: #{app_name}: Appplication Vuln(s)",
-          "query" => 
-            {
-              "status" => ["active"],
-              "tags" => ["#{app_name}"],
-              "vulnerability" =>
-              { 
-                "q" => "#{fix_string}",
-                "service_ticket_status" => ["none"],
-                "custom_fields:7952:Deferred" => ["none"]
-              }
-            }     
-        }
-    }
-
-    
-    
-          puts json_data
-          begin
-            query_post_return = RestClient::Request.execute(
-              method: :post,
-              url: @post_url,
-              payload: json_data,
-              headers: @headers
-            ) 
-
-          rescue Exception => e
-
-              puts e.message  
-              puts e.backtrace.inspect  
-
-          end 
-
-
-
-          
-
- 
-
-
-
-    # json_data = {
-    #   "asset_group" =>
-    #     {
-    #       "name" => "APP: #{app_name}: Deferred Vuln(s)",
-    #       "query" => 
-    #         {
-    #           "status" => ["active"],
-    #           "tags" => ["#{app_name}"],
-    #           "vulnerability" =>
-    #           { 
-    #             "custom_fields:7952:Deferred" => ["True","Yes"]
-    #           }
-    #         }     
-    #     }
-    # }
-
-    
-    
-    #       puts json_data
-    #       begin
-    #         query_post_return = RestClient::Request.execute(
-    #           method: :post,
-    #           url: @post_url,
-    #           payload: json_data,
-    #           headers: @headers
-    #         ) 
-
-    #       rescue Exception => e
-
-    #           puts e.message  
-    #           puts e.backtrace.inspect  
-
-    #       end   
-
-
-
 }
 
+puts "End of rows reached. All done!"


### PR DESCRIPTION
The current script requires code changes to be operational and has a lot of custom code that looks like it was built for a single use case. I generalized the script by stripping it down to just accepting a name and query string. Also added an end of script completion message.
![script_run](https://user-images.githubusercontent.com/73199391/113053850-6319d700-916e-11eb-8dd6-cf42a57fb2ea.png)
![RM_creation](https://user-images.githubusercontent.com/73199391/113053855-657c3100-916e-11eb-84e5-280770e44abd.png)
![risk_meter](https://user-images.githubusercontent.com/73199391/113053865-6745f480-916e-11eb-99de-0b1657233db5.png)
