### PR TITLE
Remove 'Show Malware Family Data API'. And some examples were updated…

### DIFF
--- a/postman/Kenna_Platform_OpenAPI_spec.json
+++ b/postman/Kenna_Platform_OpenAPI_spec.json
@@ -4320,60 +4320,6 @@
           }
         }
       },
-      "malware_family_get_response_schema": {
-        "type": "array",
-        "description": "An array of malware family information.",
-        "items": {
-          "type": "object",
-          "properties": {
-            "malware_family": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "format": "int32",
-                  "example": "24104"
-                },
-                "name": {
-                  "type": "string",
-                  "example": "SMBRelay"
-                },
-                "malware_family_type": {
-                  "type": "string",
-                  "example": "Trojan"
-                },
-                "source": {
-                  "type": "string",
-                  "example": "kenna_intel"
-                },
-                "ref_count": {
-                  "type": "integer",
-                  "format": "int32",
-                  "example": "2"
-                },
-                "curated": {
-                  "type": "boolean"
-                },
-                "vulnerability_definition_id": {
-                  "type": "integer",
-                  "format": "int32",
-                  "example": "1068593"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "example": "2020-08-07T22:15:49.000Z"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "example": "2020-08-13T20:35:02.000Z"
-                }
-              }
-            }
-          }
-        }
-      },
       "malware_hash_get_response_schema": {
         "type": "object",
         "properties": {
@@ -7108,42 +7054,46 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "application": {
-                    "id": 1,
-                    "name": "Demo App",
-                    "repo_url": "",
-                    "host_name": "Demo",
-                    "owner": "Demo",
-                    "team_name": "Demo",
-                    "business_units": "Demo Business Unit",
-                    "notes": "",
-                    "risk_meter_score": 850,
-                    "vulnerability_count": 916,
-                    "asset_count": 3,
-                    "total_vulnerability_count": 1033,
-                    "external_facing": true,
-                    "priority": 10,
-                    "open_vulnerability_count_by_risk_level": {
-                      "high": 106,
-                      "medium": 162,
-                      "low": 648,
-                      "total": 916
-                    },
-                    "historical_risk_meter_scores": [
-                      {
-                        "date": "2019-04-03",
-                        "score": 0
-                      },
-                      {
-                        "date": "2019-04-04",
-                        "score": 850
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "application": {
+                        "id": 1,
+                        "name": "Demo App",
+                        "repo_url": "",
+                        "host_name": "Demo",
+                        "owner": "Demo",
+                        "team_name": "Demo",
+                        "business_units": "Demo Business Unit",
+                        "notes": "",
+                        "risk_meter_score": 850,
+                        "vulnerability_count": 916,
+                        "asset_count": 3,
+                        "total_vulnerability_count": 1033,
+                        "external_facing": true,
+                        "priority": 10,
+                        "open_vulnerability_count_by_risk_level": {
+                          "high": 106,
+                          "medium": 162,
+                          "low": 648,
+                          "total": 916
+                        },
+                        "historical_risk_meter_scores": [
+                          {
+                            "date": "2019-04-03",
+                            "score": 0
+                          },
+                          {
+                            "date": "2019-04-04",
+                            "score": 850
+                          }
+                        ],
+                        "identifiers": [
+                          "Demo App Identifier",
+                          "Another Demo App ID"
+                        ]
                       }
-                    ],
-                    "identifiers": [
-                      "Demo App Identifier",
-                      "Another Demo App ID"
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -7156,7 +7106,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7199,7 +7151,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7239,45 +7193,49 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "application": {
-                    "id": 183,
-                    "name": "new application name",
-                    "repo_url": "app URL",
-                    "host_name": "app host",
-                    "owner": "new owner",
-                    "team_name": "team name",
-                    "business_units": "business units",
-                    "notes": "some updated notes",
-                    "risk_meter_score": 0,
-                    "vulnerability_count": 0,
-                    "asset_count": 0,
-                    "total_vulnerability_count": 0,
-                    "external_facing": true,
-                    "priority": 7,
-                    "open_vulnerability_count_by_risk_level": {
-                      "high": 0,
-                      "medium": 0,
-                      "low": 0,
-                      "total": 0
-                    },
-                    "historical_risk_meter_scores": [
-                      {
-                        "date": "2021-05-04",
-                        "score": 0
-                      },
-                      {
-                        "date": "2021-05-05",
-                        "score": 0
-                      },
-                      {
-                        "date": "2021-05-06",
-                        "score": 0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "application": {
+                        "id": 183,
+                        "name": "new application name",
+                        "repo_url": "app URL",
+                        "host_name": "app host",
+                        "owner": "new owner",
+                        "team_name": "team name",
+                        "business_units": "business units",
+                        "notes": "some updated notes",
+                        "risk_meter_score": 0,
+                        "vulnerability_count": 0,
+                        "asset_count": 0,
+                        "total_vulnerability_count": 0,
+                        "external_facing": true,
+                        "priority": 7,
+                        "open_vulnerability_count_by_risk_level": {
+                          "high": 0,
+                          "medium": 0,
+                          "low": 0,
+                          "total": 0
+                        },
+                        "historical_risk_meter_scores": [
+                          {
+                            "date": "2021-05-04",
+                            "score": 0
+                          },
+                          {
+                            "date": "2021-05-05",
+                            "score": 0
+                          },
+                          {
+                            "date": "2021-05-06",
+                            "score": 0
+                          }
+                        ],
+                        "identifiers": [
+                          "iOS Traveler"
+                        ]
                       }
-                    ],
-                    "identifiers": [
-                      "iOS Traveler"
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -7290,7 +7248,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7341,13 +7301,17 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "name",
-                  "mttr": {
-                    "High Risk Findings": 30,
-                    "Medium Risk Findings": 27,
-                    "Low Risk Findings": 5
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "name",
+                      "mttr": {
+                        "High Risk Findings": 30,
+                        "Medium Risk Findings": 27,
+                        "Low Risk Findings": 5
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -7360,7 +7324,9 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7405,13 +7371,17 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "name",
-                  "mttr": {
-                    "High Risk Vulns": 30,
-                    "Medium Risk Vulns": 27,
-                    "Low Risk Vulns": 5
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "name",
+                      "mttr": {
+                        "High Risk Vulns": 30,
+                        "Medium Risk Vulns": 27,
+                        "Low Risk Vulns": 5
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -7424,7 +7394,9 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7469,24 +7441,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "name",
-                  "historical_vulnerability_count_by_risk": {
-                    "2020-05-04": {
-                      "low": 4.0,
-                      "medium": 18.0,
-                      "high": 21.0
-                    },
-                    "2019-05-05": {
-                      "low": 4.0,
-                      "medium": 18.0,
-                      "high": 12.0
-                    },
-                    "2019-05-06": {
-                      "low": 4.0,
-                      "medium": 11.0,
-                      "high": 0.0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "name",
+                      "historical_vulnerability_count_by_risk": {
+                        "2020-05-04": {
+                          "low": 4.0,
+                          "medium": 18.0,
+                          "high": 21.0
+                        },
+                        "2019-05-05": {
+                          "low": 4.0,
+                          "medium": 18.0,
+                          "high": 12.0
+                        },
+                        "2019-05-06": {
+                          "low": 4.0,
+                          "medium": 11.0,
+                          "high": 0.0
+                        }
+                      }
                     }
                   }
                 },
@@ -7500,7 +7476,9 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7554,83 +7532,87 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "applications": [
-                    {
-                      "id": 1,
-                      "name": "Demo App",
-                      "repo_url": "",
-                      "host_name": "Demo",
-                      "owner": "Demo",
-                      "team_name": "Demo",
-                      "business_units": "Demo Business Unit",
-                      "notes": "",
-                      "risk_meter_score": 850,
-                      "vulnerability_count": 916,
-                      "asset_count": 3,
-                      "total_vulnerability_count": 1033,
-                      "external_facing": true,
-                      "priority": 10,
-                      "open_vulnerability_count_by_risk_level": {
-                        "high": 106,
-                        "medium": 162,
-                        "low": 648,
-                        "total": 916
-                      },
-                      "historical_risk_meter_scores": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "applications": [
                         {
-                          "date": "2019-04-03",
-                          "score": 0
+                          "id": 1,
+                          "name": "Demo App",
+                          "repo_url": "",
+                          "host_name": "Demo",
+                          "owner": "Demo",
+                          "team_name": "Demo",
+                          "business_units": "Demo Business Unit",
+                          "notes": "",
+                          "risk_meter_score": 850,
+                          "vulnerability_count": 916,
+                          "asset_count": 3,
+                          "total_vulnerability_count": 1033,
+                          "external_facing": true,
+                          "priority": 10,
+                          "open_vulnerability_count_by_risk_level": {
+                            "high": 106,
+                            "medium": 162,
+                            "low": 648,
+                            "total": 916
+                          },
+                          "historical_risk_meter_scores": [
+                            {
+                              "date": "2019-04-03",
+                              "score": 0
+                            },
+                            {
+                              "date": "2019-04-04",
+                              "score": 850
+                            }
+                          ],
+                          "identifiers": [
+                            "Demo App Identifier",
+                            "Another Demo App ID"
+                          ]
                         },
                         {
-                          "date": "2019-04-04",
-                          "score": 850
+                          "id": 2,
+                          "name": "Demo App 2",
+                          "repo_url": "",
+                          "host_name": "",
+                          "owner": "",
+                          "team_name": "",
+                          "business_units": "Demo Business Unit",
+                          "notes": "",
+                          "risk_meter_score": 850,
+                          "vulnerability_count": 916,
+                          "asset_count": 3,
+                          "total_vulnerability_count": 1033,
+                          "external_facing": false,
+                          "priority": 6,
+                          "open_vulnerability_count_by_risk_level": {
+                            "high": 106,
+                            "medium": 162,
+                            "low": 648,
+                            "total": 916
+                          },
+                          "historical_risk_meter_scores": [
+                            {
+                              "date": "2019-04-06",
+                              "score": 850
+                            },
+                            {
+                              "date": "2019-04-09",
+                              "score": 850
+                            }
+                          ],
+                          "identifiers": [
+                            "Yet another ID"
+                          ]
                         }
                       ],
-                      "identifiers": [
-                        "Demo App Identifier",
-                        "Another Demo App ID"
-                      ]
-                    },
-                    {
-                      "id": 2,
-                      "name": "Demo App 2",
-                      "repo_url": "",
-                      "host_name": "",
-                      "owner": "",
-                      "team_name": "",
-                      "business_units": "Demo Business Unit",
-                      "notes": "",
-                      "risk_meter_score": 850,
-                      "vulnerability_count": 916,
-                      "asset_count": 3,
-                      "total_vulnerability_count": 1033,
-                      "external_facing": false,
-                      "priority": 6,
-                      "open_vulnerability_count_by_risk_level": {
-                        "high": 106,
-                        "medium": 162,
-                        "low": 648,
-                        "total": 916
-                      },
-                      "historical_risk_meter_scores": [
-                        {
-                          "date": "2019-04-06",
-                          "score": 850
-                        },
-                        {
-                          "date": "2019-04-09",
-                          "score": 850
-                        }
-                      ],
-                      "identifiers": [
-                        "Yet another ID"
-                      ]
+                      "meta": {
+                        "page": 1,
+                        "pages": 3
+                      }
                     }
-                  ],
-                  "meta": {
-                    "page": 1,
-                    "pages": 3
                   }
                 },
                 "schema": {
@@ -7654,7 +7636,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7686,34 +7670,38 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "application": {
-                    "id": 18408,
-                    "name": "Demo app",
-                    "repo_url": "Demo repo URL",
-                    "host_name": "Demo host name",
-                    "owner": "Demo owner",
-                    "team_name": "Demo team",
-                    "business_units": "Demo business units",
-                    "notes": "Demo notes",
-                    "risk_meter_score": 0,
-                    "vulnerability_count": 0,
-                    "asset_count": 0,
-                    "total_vulnerability_count": 0,
-                    "external_facing": true,
-                    "priority": 10,
-                    "open_vulnerability_count_by_risk_level": {
-                      "high": 0,
-                      "medium": 0,
-                      "low": 0,
-                      "total": 0
-                    },
-                    "historical_risk_meter_scores": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "application": {
+                        "id": 18408,
+                        "name": "Demo app",
+                        "repo_url": "Demo repo URL",
+                        "host_name": "Demo host name",
+                        "owner": "Demo owner",
+                        "team_name": "Demo team",
+                        "business_units": "Demo business units",
+                        "notes": "Demo notes",
+                        "risk_meter_score": 0,
+                        "vulnerability_count": 0,
+                        "asset_count": 0,
+                        "total_vulnerability_count": 0,
+                        "external_facing": true,
+                        "priority": 10,
+                        "open_vulnerability_count_by_risk_level": {
+                          "high": 0,
+                          "medium": 0,
+                          "low": 0,
+                          "total": 0
+                        },
+                        "historical_risk_meter_scores": [
 
-                    ],
-                    "identifiers": [
-                      "WA-123"
-                    ]
+                        ],
+                        "identifiers": [
+                          "WA-123"
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -7726,7 +7714,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7780,7 +7770,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7829,46 +7821,50 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "asset_group": {
-                    "parent": null,
-                    "child_ids": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset_group": {
+                        "parent": null,
+                        "child_ids": [
 
-                    ],
-                    "id": 2,
-                    "resource": "asset",
-                    "name": "name",
-                    "querystring": "querystring=test&foo=bar",
-                    "created_at": "2015-02-04T21:25:49Z",
-                    "updated_at": "2015-02-04T21:25:49Z",
-                    "risk_meter_score": 0,
-                    "true_risk_meter_score": 0,
-                    "asset_count": 0,
-                    "unique_open_cve_count": 0,
-                    "predicted_exploitable_count": 0,
-                    "highest_score": {
-                      "date": "2015-02-04",
-                      "score": 0
-                    },
-                    "lowest_score": {
-                      "date": "2015-02-04",
-                      "score": 0
-                    },
-                    "score_last_week": null,
-                    "score_last_month": {
-                      "date": "2015-02-04",
-                      "score": 0,
-                      "delta": 0
-                    },
-                    "score_90_days_ago": {
-                      "date": "2015-02-04",
-                      "score": 0,
-                      "delta": 0
-                    },
-                    "vulnerability_density": 0,
-                    "historical_risk_meter_scores": [
-                      0
-                    ]
+                        ],
+                        "id": 2,
+                        "resource": "asset",
+                        "name": "name",
+                        "querystring": "querystring=test&foo=bar",
+                        "created_at": "2015-02-04T21:25:49Z",
+                        "updated_at": "2015-02-04T21:25:49Z",
+                        "risk_meter_score": 0,
+                        "true_risk_meter_score": 0,
+                        "asset_count": 0,
+                        "unique_open_cve_count": 0,
+                        "predicted_exploitable_count": 0,
+                        "highest_score": {
+                          "date": "2015-02-04",
+                          "score": 0
+                        },
+                        "lowest_score": {
+                          "date": "2015-02-04",
+                          "score": 0
+                        },
+                        "score_last_week": null,
+                        "score_last_month": {
+                          "date": "2015-02-04",
+                          "score": 0,
+                          "delta": 0
+                        },
+                        "score_90_days_ago": {
+                          "date": "2015-02-04",
+                          "score": 0,
+                          "delta": 0
+                        },
+                        "vulnerability_density": 0,
+                        "historical_risk_meter_scores": [
+                          0
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -7886,7 +7882,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7929,7 +7927,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -7971,51 +7971,55 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "fixes": [
-                    {
-                      "id": "VendorAdvisory:111",
-                      "alternative_visible": true,
-                      "assets": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "fixes": [
                         {
-                          "id": 555,
-                          "locator": "localhost",
-                          "ip_address_locator": "ip_address",
-                          "file_locator": "file",
-                          "hostname_locator": "hostname",
-                          "url_locator": "url",
-                          "netbios_locator": "netbios"
+                          "id": "VendorAdvisory:111",
+                          "alternative_visible": true,
+                          "assets": [
+                            {
+                              "id": 555,
+                              "locator": "localhost",
+                              "ip_address_locator": "ip_address",
+                              "file_locator": "file",
+                              "hostname_locator": "hostname",
+                              "url_locator": "url",
+                              "netbios_locator": "netbios"
+                            }
+                          ],
+                          "cves": [
+                            "CVE-2006-4924",
+                            "CVE-2006-5051"
+                          ],
+                          "exact_match": false,
+                          "updated_at": "5/19/2015",
+                          "patch_publication_date": "4/21/2009",
+                          "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                          "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                          "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
+                          "name": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "urls": [
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
+                          ],
+                          "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                          "vendor": "oracle",
+                          "scanner_ids": [
+                            1
+                          ],
+                          "category": "Ubuntu",
+                          "vuln_count": 7
                         }
                       ],
-                      "cves": [
-                        "CVE-2006-4924",
-                        "CVE-2006-5051"
-                      ],
-                      "exact_match": false,
-                      "updated_at": "5/19/2015",
-                      "patch_publication_date": "4/21/2009",
-                      "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                      "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                      "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
-                      "name": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "urls": [
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
-                      ],
-                      "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                      "vendor": "oracle",
-                      "scanner_ids": [
-                        1
-                      ],
-                      "category": "Ubuntu",
-                      "vuln_count": 7
+                      "meta": {
+                        "total_count": 34,
+                        "page": 1,
+                        "pages": 4
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 34,
-                    "page": 1,
-                    "pages": 4
                   }
                 },
                 "schema": {
@@ -8039,7 +8043,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8105,14 +8111,18 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "test asset group",
-                  "mttr": {
-                    "All findings": 10,
-                    "High risk": 0,
-                    "Medium risk": 4,
-                    "Low risk": 6
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "test asset group",
+                      "mttr": {
+                        "All findings": 10,
+                        "High risk": 0,
+                        "Medium risk": 4,
+                        "Low risk": 6
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -8125,7 +8135,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8183,24 +8195,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "historical_avg_days_open_vulnerabilities_by_risk_level": {
-                    "2020-05-24": {
-                      "low": 9.0,
-                      "medium": 6.0,
-                      "high": 3.0
-                    },
-                    "2020-05-25": {
-                      "low": 9.0,
-                      "medium": 6.0,
-                      "high": 3.0
-                    },
-                    "2020-05-26": {
-                      "low": 9.0,
-                      "medium": 6.0,
-                      "high": 2.0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "historical_avg_days_open_vulnerabilities_by_risk_level": {
+                        "2020-05-24": {
+                          "low": 9.0,
+                          "medium": 6.0,
+                          "high": 3.0
+                        },
+                        "2020-05-25": {
+                          "low": 9.0,
+                          "medium": 6.0,
+                          "high": 3.0
+                        },
+                        "2020-05-26": {
+                          "low": 9.0,
+                          "medium": 6.0,
+                          "high": 2.0
+                        }
+                      }
                     }
                   }
                 },
@@ -8214,7 +8230,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8272,24 +8290,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "historical_false_positives_by_risk_level": {
-                    "2020-05-24": {
-                      "low": 5.0,
-                      "medium": 2.0,
-                      "high": 1.0
-                    },
-                    "2020-05-25": {
-                      "low": 5.0,
-                      "medium": 2.0,
-                      "high": 0.0
-                    },
-                    "2020-05-26": {
-                      "low": 5.0,
-                      "medium": 0.0,
-                      "high": 0.0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "historical_false_positives_by_risk_level": {
+                        "2020-05-24": {
+                          "low": 5.0,
+                          "medium": 2.0,
+                          "high": 1.0
+                        },
+                        "2020-05-25": {
+                          "low": 5.0,
+                          "medium": 2.0,
+                          "high": 0.0
+                        },
+                        "2020-05-26": {
+                          "low": 5.0,
+                          "medium": 0.0,
+                          "high": 0.0
+                        }
+                      }
                     }
                   }
                 },
@@ -8303,7 +8325,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8369,14 +8393,18 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "name",
-                  "mttr": {
-                    "All vulnerabilities": 1,
-                    "High risk": 1,
-                    "Medium risk": 2,
-                    "Low risk": 0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "name",
+                      "mttr": {
+                        "All vulnerabilities": 1,
+                        "High risk": 1,
+                        "Medium risk": 2,
+                        "Low risk": 0
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -8389,7 +8417,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8447,24 +8477,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 5500,
-                  "name": "A risk meter",
-                  "historical_vulnerability_count_by_risk": {
-                    "2017-07-02": {
-                      "low": 440,
-                      "medium": 330,
-                      "high": 100
-                    },
-                    "2017-07-03": {
-                      "low": 440,
-                      "medium": 320,
-                      "high": 50
-                    },
-                    "2017-07-04": {
-                      "low": 438,
-                      "medium": 300,
-                      "high": 42
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 5500,
+                      "name": "A risk meter",
+                      "historical_vulnerability_count_by_risk": {
+                        "2017-07-02": {
+                          "low": 440,
+                          "medium": 330,
+                          "high": 100
+                        },
+                        "2017-07-03": {
+                          "low": 440,
+                          "medium": 320,
+                          "high": 50
+                        },
+                        "2017-07-04": {
+                          "low": 438,
+                          "medium": 300,
+                          "high": 42
+                        }
+                      }
                     }
                   }
                 },
@@ -8478,7 +8512,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8536,24 +8572,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "historical_past_due_vulnerabilities_by_risk_level": {
-                    "2020-05-24": {
-                      "low": 24048.0,
-                      "medium": 2.0,
-                      "high": 1.0
-                    },
-                    "2020-05-25": {
-                      "low": 240485.0,
-                      "medium": 2.0,
-                      "high": 0.0
-                    },
-                    "2020-05-26": {
-                      "low": 240481.0,
-                      "medium": 0.0,
-                      "high": 0.0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "historical_past_due_vulnerabilities_by_risk_level": {
+                        "2020-05-24": {
+                          "low": 24048.0,
+                          "medium": 2.0,
+                          "high": 1.0
+                        },
+                        "2020-05-25": {
+                          "low": 240485.0,
+                          "medium": 2.0,
+                          "high": 0.0
+                        },
+                        "2020-05-26": {
+                          "low": 240481.0,
+                          "medium": 0.0,
+                          "high": 0.0
+                        }
+                      }
                     }
                   }
                 },
@@ -8567,7 +8607,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8625,15 +8667,19 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 5500,
-                  "name": "A risk meter",
-                  "risk_meter_scores": {
-                    "2021-08-21": 800,
-                    "2021-09-22": 400,
-                    "2021-09-23": 300,
-                    "2021-09-24": 200,
-                    "2021-09-25": 100
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 5500,
+                      "name": "A risk meter",
+                      "risk_meter_scores": {
+                        "2021-08-21": 800,
+                        "2021-09-22": 400,
+                        "2021-09-23": 300,
+                        "2021-09-24": 200,
+                        "2021-09-25": 100
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -8646,7 +8692,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8704,24 +8752,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "risk_accepted_over_time": {
-                    "2021-06-22": {
-                      "low": 101,
-                      "medium": 6,
-                      "high": 1
-                    },
-                    "2021-06-23": {
-                      "low": 101,
-                      "medium": 4,
-                      "high": 0
-                    },
-                    "2021-06-24": {
-                      "low": 101,
-                      "medium": 0,
-                      "high": 0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "risk_accepted_over_time": {
+                        "2021-06-22": {
+                          "low": 101,
+                          "medium": 6,
+                          "high": 1
+                        },
+                        "2021-06-23": {
+                          "low": 101,
+                          "medium": 4,
+                          "high": 0
+                        },
+                        "2021-06-24": {
+                          "low": 101,
+                          "medium": 0,
+                          "high": 0
+                        }
+                      }
                     }
                   }
                 },
@@ -8735,7 +8787,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8777,13 +8831,17 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "total_past_due_vulnerabilities_by_risk_level": {
-                    "high": 0,
-                    "medium": 1,
-                    "low": 2300
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "total_past_due_vulnerabilities_by_risk_level": {
+                        "high": 0,
+                        "medium": 1,
+                        "low": 2300
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -8796,7 +8854,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8838,35 +8898,39 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 183,
-                  "name": "A risk meter",
-                  "vulnerabilities_by_due_date": [
-                    {
-                      "name": "Due in 30+ Days",
-                      "count": 0
-                    },
-                    {
-                      "name": "Due in 0 to 30 Days",
-                      "count": 0
-                    },
-                    {
-                      "name": "Past Due 1 to 30 Days",
-                      "count": 67
-                    },
-                    {
-                      "name": "Past Due 30 to 60 Days",
-                      "count": 29
-                    },
-                    {
-                      "name": "Past Due 60 to 90 Days",
-                      "count": 0
-                    },
-                    {
-                      "name": "Past Due 90+ Days",
-                      "count": 89446
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 183,
+                      "name": "A risk meter",
+                      "vulnerabilities_by_due_date": [
+                        {
+                          "name": "Due in 30+ Days",
+                          "count": 0
+                        },
+                        {
+                          "name": "Due in 0 to 30 Days",
+                          "count": 0
+                        },
+                        {
+                          "name": "Past Due 1 to 30 Days",
+                          "count": 67
+                        },
+                        {
+                          "name": "Past Due 30 to 60 Days",
+                          "count": 29
+                        },
+                        {
+                          "name": "Past Due 60 to 90 Days",
+                          "count": 0
+                        },
+                        {
+                          "name": "Past Due 90+ Days",
+                          "count": 89446
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/asset_groups_vulns_by_due_date_schema"
@@ -8878,7 +8942,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -8942,46 +9008,50 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "asset_group": {
-                    "id": 2,
-                    "name": "name",
-                    "risk_meter_score": 580,
-                    "top_fixes": [
-                      {
-                        "fix_group_number": 1,
-                        "risk_score_reduction": 23,
-                        "fixes": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset_group": {
+                        "id": 2,
+                        "name": "name",
+                        "risk_meter_score": 580,
+                        "top_fixes": [
                           {
-                            "id": 36271,
-                            "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                            "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                            "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                            "consequence": null,
-                            "assets": [
+                            "fix_group_number": 1,
+                            "risk_score_reduction": 23,
+                            "fixes": [
                               {
-                                "id": 1234,
-                                "locator": "127.0.0.1",
-                                "primary_locator": "ip_address",
-                                "hostname": null,
-                                "mac_address": null,
-                                "netbios": null,
-                                "fqdn": null,
-                                "ip_address": "127.0.0.1",
-                                "url": null,
-                                "file": null,
-                                "database": null,
-                                "application": null
+                                "id": 36271,
+                                "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                                "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                                "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                                "consequence": null,
+                                "assets": [
+                                  {
+                                    "id": 1234,
+                                    "locator": "127.0.0.1",
+                                    "primary_locator": "ip_address",
+                                    "hostname": null,
+                                    "mac_address": null,
+                                    "netbios": null,
+                                    "fqdn": null,
+                                    "ip_address": "127.0.0.1",
+                                    "url": null,
+                                    "file": null,
+                                    "database": null,
+                                    "application": null
+                                  }
+                                ],
+                                "cves": [
+                                  "CVE-2005-1083"
+                                ],
+                                "category": "Ubuntu"
                               }
-                            ],
-                            "cves": [
-                              "CVE-2005-1083"
-                            ],
-                            "category": "Ubuntu"
+                            ]
                           }
                         ]
                       }
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -8999,7 +9069,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9041,58 +9113,62 @@
             "description": "201",
             "content": {
               "application/json": {
-                "example": {
-                  "asset_group": {
-                    "asset_count": 2,
-                    "child_ids": null,
-                    "client_id": 173,
-                    "created_at": "2022-01-18T01:13:23Z",
-                    "full_query": [
-                      {
-                        "status": [
-                          "active"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset_group": {
+                        "asset_count": 2,
+                        "child_ids": null,
+                        "client_id": 173,
+                        "created_at": "2022-01-18T01:13:23Z",
+                        "full_query": [
+                          {
+                            "status": [
+                              "active"
+                            ],
+                            "tags": [
+                              "electric_grid"
+                            ],
+                            "vulnerability": {
+                              "status": [
+                                "open"
+                              ]
+                            }
+                          },
+                          {
+                            "status": [
+                              "active"
+                            ],
+                            "tags": [
+                              "Cupertino"
+                            ],
+                            "vulnerability": {
+                              "status": [
+                                "open"
+                              ]
+                            }
+                          }
                         ],
-                        "tags": [
-                          "electric_grid"
-                        ],
-                        "vulnerability": {
-                          "status": [
-                            "open"
-                          ]
-                        }
-                      },
-                      {
-                        "status": [
-                          "active"
-                        ],
-                        "tags": [
-                          "Cupertino"
-                        ],
-                        "vulnerability": {
-                          "status": [
-                            "open"
-                          ]
-                        }
+                        "id": 344100,
+                        "name": "electric_grid",
+                        "parent": {
+                          "client_id": 173,
+                          "created_at": "2022-01-18T01:13:23.000Z",
+                          "id": 344099,
+                          "name": "Cupertino",
+                          "parent_id": null,
+                          "querystring": "status%5B%5D=active&tags%5B%5D=Cupertino&vulnerability%5Bstatus%5D%5B%5D=open",
+                          "resource": "asset",
+                          "updated_at": "2022-01-18T01:13:23.000Z"
+                        },
+                        "parent_id": 344099,
+                        "querystring": "status%5B%5D=active&tags%5B%5D=electric_grid&vulnerability%5Bstatus%5D%5B%5D=open",
+                        "resource": "asset",
+                        "risk_meter_score": 870,
+                        "true_risk_meter_score": 0,
+                        "updated_at": "2022-01-18T01:13:23Z"
                       }
-                    ],
-                    "id": 344100,
-                    "name": "electric_grid",
-                    "parent": {
-                      "client_id": 173,
-                      "created_at": "2022-01-18T01:13:23.000Z",
-                      "id": 344099,
-                      "name": "Cupertino",
-                      "parent_id": null,
-                      "querystring": "status%5B%5D=active&tags%5B%5D=Cupertino&vulnerability%5Bstatus%5D%5B%5D=open",
-                      "resource": "asset",
-                      "updated_at": "2022-01-18T01:13:23.000Z"
-                    },
-                    "parent_id": 344099,
-                    "querystring": "status%5B%5D=active&tags%5B%5D=electric_grid&vulnerability%5Bstatus%5D%5B%5D=open",
-                    "resource": "asset",
-                    "risk_meter_score": 870,
-                    "true_risk_meter_score": 0,
-                    "updated_at": "2022-01-18T01:13:23Z"
+                    }
                   }
                 },
                 "schema": {
@@ -9105,7 +9181,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9165,49 +9243,53 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "meta": {
-                    "page": 4,
-                    "pages": 20,
-                    "total_count": 597
-                  },
-                  "asset_groups": [
-                    {
-                      "id": 132,
-                      "resource": "asset",
-                      "name": "name",
-                      "querystring": "querystring=test&foo=bar",
-                      "created_at": "2015-02-04T21:25:49Z",
-                      "updated_at": "2015-02-04T21:25:49Z",
-                      "risk_meter_score": 880,
-                      "asset_count": 3,
-                      "unique_open_cve_count": 0,
-                      "predicted_exploitable_count": 0,
-                      "highest_score": {
-                        "date": "2015-02-04",
-                        "score": 0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "meta": {
+                        "page": 4,
+                        "pages": 20,
+                        "total_count": 597
                       },
-                      "lowest_score": {
-                        "date": "2015-02-04",
-                        "score": 0
-                      },
-                      "score_last_week": null,
-                      "score_last_month": {
-                        "date": "2015-02-04",
-                        "score": 0,
-                        "delta": 0
-                      },
-                      "score_90_days_ago": {
-                        "date": "2015-02-04",
-                        "score": 0,
-                        "delta": 0
-                      },
-                      "vulnerability_density": 0,
-                      "historical_risk_meter_scores": [
-                        0
+                      "asset_groups": [
+                        {
+                          "id": 132,
+                          "resource": "asset",
+                          "name": "name",
+                          "querystring": "querystring=test&foo=bar",
+                          "created_at": "2015-02-04T21:25:49Z",
+                          "updated_at": "2015-02-04T21:25:49Z",
+                          "risk_meter_score": 880,
+                          "asset_count": 3,
+                          "unique_open_cve_count": 0,
+                          "predicted_exploitable_count": 0,
+                          "highest_score": {
+                            "date": "2015-02-04",
+                            "score": 0
+                          },
+                          "lowest_score": {
+                            "date": "2015-02-04",
+                            "score": 0
+                          },
+                          "score_last_week": null,
+                          "score_last_month": {
+                            "date": "2015-02-04",
+                            "score": 0,
+                            "delta": 0
+                          },
+                          "score_90_days_ago": {
+                            "date": "2015-02-04",
+                            "score": 0,
+                            "delta": 0
+                          },
+                          "vulnerability_density": 0,
+                          "historical_risk_meter_scores": [
+                            0
+                          ]
+                        }
                       ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "type": "object",
@@ -9230,7 +9312,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9262,38 +9346,42 @@
             "description": "201",
             "content": {
               "application/json": {
-                "example": {
-                  "asset_group": {
-                    "asset_count": 3,
-                    "child_ids": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset_group": {
+                        "asset_count": 3,
+                        "child_ids": [
 
-                    ],
-                    "client_id": 17312,
-                    "created_at": "2022-01-18T01:13:23Z",
-                    "full_query": [
-                      {
-                        "status": [
-                          "active"
                         ],
-                        "tags": [
-                          "Cupertino"
+                        "client_id": 17312,
+                        "created_at": "2022-01-18T01:13:23Z",
+                        "full_query": [
+                          {
+                            "status": [
+                              "active"
+                            ],
+                            "tags": [
+                              "Cupertino"
+                            ],
+                            "vulnerability": {
+                              "status": [
+                                "open"
+                              ]
+                            }
+                          }
                         ],
-                        "vulnerability": {
-                          "status": [
-                            "open"
-                          ]
-                        }
+                        "id": 344099,
+                        "name": "Cupertino",
+                        "parent": null,
+                        "parent_id": null,
+                        "querystring": "status%5B%5D=active&tags%5B%5D=Cupertino&vulnerability%5Bstatus%5D%5B%5D=open",
+                        "resource": "asset",
+                        "risk_meter_score": 880,
+                        "true_risk_meter_score": 0,
+                        "updated_at": "2022-01-18T01:13:23Z"
                       }
-                    ],
-                    "id": 344099,
-                    "name": "Cupertino",
-                    "parent": null,
-                    "parent_id": null,
-                    "querystring": "status%5B%5D=active&tags%5B%5D=Cupertino&vulnerability%5Bstatus%5D%5B%5D=open",
-                    "resource": "asset",
-                    "risk_meter_score": 880,
-                    "true_risk_meter_score": 0,
-                    "updated_at": "2022-01-18T01:13:23Z"
+                    }
                   }
                 },
                 "schema": {
@@ -9311,7 +9399,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9405,62 +9495,66 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "asset": {
-                    "id": 183,
-                    "created_at": "2013-09-24T15:50:21Z",
-                    "last_seen_time": "2013-09-30T20:00:30Z",
-                    "operating_system": null,
-                    "last_booted_at": null,
-                    "ipv6": null,
-                    "locator": "http://www.example.com",
-                    "primary_locator": "url",
-                    "network_ports": [
-                      {
-                        "id": 600002,
-                        "protocol": "TCP",
-                        "port_number": 8080,
-                        "name": "http",
-                        "product": "tomcat",
-                        "version": "7.0.61",
-                        "state": "running",
-                        "ostype": "windows"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset": {
+                        "id": 183,
+                        "created_at": "2013-09-24T15:50:21Z",
+                        "last_seen_time": "2013-09-30T20:00:30Z",
+                        "operating_system": null,
+                        "last_booted_at": null,
+                        "ipv6": null,
+                        "locator": "http://www.example.com",
+                        "primary_locator": "url",
+                        "network_ports": [
+                          {
+                            "id": 600002,
+                            "protocol": "TCP",
+                            "port_number": 8080,
+                            "name": "http",
+                            "product": "tomcat",
+                            "version": "7.0.61",
+                            "state": "running",
+                            "ostype": "windows"
+                          }
+                        ],
+                        "tags": [
+                          "nihil",
+                          "facilis",
+                          "quo"
+                        ],
+                        "vulnerabilities_count": 1,
+                        "inactive_at": "2020-10-31",
+                        "status_set_manually": false,
+                        "overage": false,
+                        "urls": {
+                          "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
+                        },
+                        "notes": null,
+                        "priority": 1,
+                        "hostname": null,
+                        "mac_address": null,
+                        "ec2": null,
+                        "external_id": null,
+                        "netbios": null,
+                        "fqdn": null,
+                        "ip_address": "127.0.0.1",
+                        "url": null,
+                        "file": null,
+                        "database": null,
+                        "application": null,
+                        "risk_meter_score": 0,
+                        "asset_groups": [
+                          {
+                            "id": 1,
+                            "name": "name"
+                          }
+                        ],
+                        "status": "active",
+                        "owner": "Freddy"
                       }
-                    ],
-                    "tags": [
-                      "nihil",
-                      "facilis",
-                      "quo"
-                    ],
-                    "vulnerabilities_count": 1,
-                    "inactive_at": "2020-10-31",
-                    "status_set_manually": false,
-                    "overage": false,
-                    "urls": {
-                      "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
-                    },
-                    "notes": null,
-                    "priority": 1,
-                    "hostname": null,
-                    "mac_address": null,
-                    "ec2": null,
-                    "external_id": null,
-                    "netbios": null,
-                    "fqdn": null,
-                    "ip_address": "127.0.0.1",
-                    "url": null,
-                    "file": null,
-                    "database": null,
-                    "application": null,
-                    "risk_meter_score": 0,
-                    "asset_groups": [
-                      {
-                        "id": 1,
-                        "name": "name"
-                      }
-                    ],
-                    "status": "active",
-                    "owner": "Freddy"
+                    }
                   }
                 },
                 "schema": {
@@ -9478,7 +9572,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9606,47 +9702,51 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "tags": [
-                    "foo",
-                    "bar"
-                  ],
-                  "tag_info": [
-                    {
-                      "tag_name": "foo",
-                      "tag_sources": {
-                        "connectors": [
-                          {
-                            "connector_id": 541846,
-                            "last_seen_at": "2022-02-02"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "tags": [
+                        "foo",
+                        "bar"
+                      ],
+                      "tag_info": [
+                        {
+                          "tag_name": "foo",
+                          "tag_sources": {
+                            "connectors": [
+                              {
+                                "connector_id": 541846,
+                                "last_seen_at": "2022-02-02"
+                              }
+                            ],
+                            "api": {
+                              "user_id": 478414
+                            },
+                            "ui": {
+                              "user_id": 245244
+                            }
                           }
-                        ],
-                        "api": {
-                          "user_id": 478414
                         },
-                        "ui": {
-                          "user_id": 245244
-                        }
-                      }
-                    },
-                    {
-                      "tag_name": "bar",
-                      "tag_sources": {
-                        "connectors": [
-                          {
-                            "connector_id": 461843,
-                            "last_seen_at": "2022-01-01"
+                        {
+                          "tag_name": "bar",
+                          "tag_sources": {
+                            "connectors": [
+                              {
+                                "connector_id": 461843,
+                                "last_seen_at": "2022-01-01"
+                              }
+                            ],
+                            "api": {
+                              "user_id": 154315
+                            },
+                            "ui": {
+                              "user_id": 758152
+                            }
                           }
-                        ],
-                        "api": {
-                          "user_id": 154315
-                        },
-                        "ui": {
-                          "user_id": 758152
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/tags_get_response_schema"
@@ -9658,7 +9758,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9700,41 +9802,45 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerabilities": [
-                    {
-                      "id": 121201,
-                      "closed": true,
-                      "closed_at": "2015-02-10T10:50:17Z",
-                      "status": "closed",
-                      "created_at": "2015-02-10T10:50:17Z",
-                      "last_seen_time": "2015-02-15T10:25:17Z",
-                      "notes": null,
-                      "priority": 0,
-                      "score": 15,
-                      "threat": 10,
-                      "severity": 5,
-                      "solution": "A type confusion vulnerability can occur when manipulating JavaScript objects due to issues in Array.pop. This can allow for an exploitable crash. We are aware of targeted attacks in the wild abusing this flaw. This vulnerability affects Firefox ESR &lt; 60.7.1, Firefox &lt; 67.0.3, and Thunderbird &lt; 60.7.2.",
-                      "identifiers": [
-                        "86847"
-                      ],
-                      "urls": {
-                        "asset": "https://api.kennasecurity.com/asset/536"
-                      },
-                      "patch": false,
-                      "patch_published_at": null,
-                      "description": null,
-                      "cve_id": "CVE-2007-6750",
-                      "wasc_id": null,
-                      "asset_id": 536,
-                      "first_found_on": "2009-06-20T18:12:08Z",
-                      "easily_exploitable": false,
-                      "malware_exploitable": false,
-                      "top_priority": false,
-                      "active_internet_breach": false,
-                      "popular_target": false
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerabilities": [
+                        {
+                          "id": 121201,
+                          "closed": true,
+                          "closed_at": "2015-02-10T10:50:17Z",
+                          "status": "closed",
+                          "created_at": "2015-02-10T10:50:17Z",
+                          "last_seen_time": "2015-02-15T10:25:17Z",
+                          "notes": null,
+                          "priority": 0,
+                          "score": 15,
+                          "threat": 10,
+                          "severity": 5,
+                          "solution": "A type confusion vulnerability can occur when manipulating JavaScript objects due to issues in Array.pop. This can allow for an exploitable crash. We are aware of targeted attacks in the wild abusing this flaw. This vulnerability affects Firefox ESR &lt; 60.7.1, Firefox &lt; 67.0.3, and Thunderbird &lt; 60.7.2.",
+                          "identifiers": [
+                            "86847"
+                          ],
+                          "urls": {
+                            "asset": "https://api.kennasecurity.com/asset/536"
+                          },
+                          "patch": false,
+                          "patch_published_at": null,
+                          "description": null,
+                          "cve_id": "CVE-2007-6750",
+                          "wasc_id": null,
+                          "asset_id": 536,
+                          "first_found_on": "2009-06-20T18:12:08Z",
+                          "easily_exploitable": false,
+                          "malware_exploitable": false,
+                          "top_priority": false,
+                          "active_internet_breach": false,
+                          "popular_target": false
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "type": "object",
@@ -9754,7 +9860,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -9809,68 +9917,72 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "assets": [
-                    {
-                      "id": 183,
-                      "created_at": "2015-08-06T12:37:54Z",
-                      "last_seen_time": "2015-08-12T15:00:54Z",
-                      "operating_system": null,
-                      "last_booted_at": null,
-                      "ipv6": null,
-                      "locator": "http://www.example.com",
-                      "primary_locator": "url",
-                      "network_ports": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "assets": [
                         {
-                          "id": 600002,
-                          "protocol": "TCP",
-                          "port_number": 8080,
-                          "name": "http",
-                          "product": "tomcat",
-                          "version": "7.0.61",
-                          "state": "running",
-                          "ostype": "windows"
+                          "id": 183,
+                          "created_at": "2015-08-06T12:37:54Z",
+                          "last_seen_time": "2015-08-12T15:00:54Z",
+                          "operating_system": null,
+                          "last_booted_at": null,
+                          "ipv6": null,
+                          "locator": "http://www.example.com",
+                          "primary_locator": "url",
+                          "network_ports": [
+                            {
+                              "id": 600002,
+                              "protocol": "TCP",
+                              "port_number": 8080,
+                              "name": "http",
+                              "product": "tomcat",
+                              "version": "7.0.61",
+                              "state": "running",
+                              "ostype": "windows"
+                            }
+                          ],
+                          "tags": [
+                            "nihil",
+                            "facilis",
+                            "quo"
+                          ],
+                          "vulnerabilities_count": 1,
+                          "inactive_at": "2020-10-31",
+                          "status_set_manually": false,
+                          "overage": false,
+                          "urls": {
+                            "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
+                          },
+                          "notes": null,
+                          "priority": 1,
+                          "hostname": null,
+                          "mac_address": null,
+                          "ec2": null,
+                          "external_id": null,
+                          "netbios": null,
+                          "fqdn": null,
+                          "ip_address": "127.0.0.1",
+                          "url": null,
+                          "file": null,
+                          "database": null,
+                          "application": null,
+                          "risk_meter_score": 0,
+                          "asset_groups": [
+                            {
+                              "id": 1,
+                              "name": "name"
+                            }
+                          ],
+                          "status": "active",
+                          "owner": "Freddy"
                         }
                       ],
-                      "tags": [
-                        "nihil",
-                        "facilis",
-                        "quo"
-                      ],
-                      "vulnerabilities_count": 1,
-                      "inactive_at": "2020-10-31",
-                      "status_set_manually": false,
-                      "overage": false,
-                      "urls": {
-                        "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
-                      },
-                      "notes": null,
-                      "priority": 1,
-                      "hostname": null,
-                      "mac_address": null,
-                      "ec2": null,
-                      "external_id": null,
-                      "netbios": null,
-                      "fqdn": null,
-                      "ip_address": "127.0.0.1",
-                      "url": null,
-                      "file": null,
-                      "database": null,
-                      "application": null,
-                      "risk_meter_score": 0,
-                      "asset_groups": [
-                        {
-                          "id": 1,
-                          "name": "name"
-                        }
-                      ],
-                      "status": "active",
-                      "owner": "Freddy"
+                      "meta": {
+                        "page": 1,
+                        "pages": 30
+                      }
                     }
-                  ],
-                  "meta": {
-                    "page": 1,
-                    "pages": 30
                   }
                 },
                 "schema": {
@@ -9914,43 +10026,47 @@
             "description": "201",
             "content": {
               "application/json": {
-                "example": {
-                  "asset": {
-                    "id": 183,
-                    "created_at": "2017-05-30T15:50:21Z",
-                    "operating_system": null,
-                    "last_booted_at": null,
-                    "ipv6": null,
-                    "locator": "54.38.148.231",
-                    "primary_locator": "ip_address",
-                    "vulnerabilities_count": 0,
-                    "inactive_at": "2020-10-31",
-                    "status_set_manually": false,
-                    "overage": false,
-                    "urls": {
-                      "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
-                    },
-                    "priority": null,
-                    "notes": null,
-                    "hostname": null,
-                    "mac_address": null,
-                    "external_id": null,
-                    "netbios": null,
-                    "fqdn": null,
-                    "ip_address": "54.38.148.231",
-                    "url": null,
-                    "database": null,
-                    "file": null,
-                    "application": null,
-                    "risk_meter_score": 0,
-                    "asset_groups": [
-                      {
-                        "id": 1,
-                        "name": "name"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "asset": {
+                        "id": 183,
+                        "created_at": "2017-05-30T15:50:21Z",
+                        "operating_system": null,
+                        "last_booted_at": null,
+                        "ipv6": null,
+                        "locator": "54.38.148.231",
+                        "primary_locator": "ip_address",
+                        "vulnerabilities_count": 0,
+                        "inactive_at": "2020-10-31",
+                        "status_set_manually": false,
+                        "overage": false,
+                        "urls": {
+                          "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
+                        },
+                        "priority": null,
+                        "notes": null,
+                        "hostname": null,
+                        "mac_address": null,
+                        "external_id": null,
+                        "netbios": null,
+                        "fqdn": null,
+                        "ip_address": "54.38.148.231",
+                        "url": null,
+                        "database": null,
+                        "file": null,
+                        "application": null,
+                        "risk_meter_score": 0,
+                        "asset_groups": [
+                          {
+                            "id": 1,
+                            "name": "name"
+                          }
+                        ],
+                        "ec2": null,
+                        "last_seen_time": null
                       }
-                    ],
-                    "ec2": null,
-                    "last_seen_time": null
+                    }
                   }
                 },
                 "schema": {
@@ -9968,10 +10084,14 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "unproccessable_entity",
-                  "message": "param is missing or the value is empty: asset"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "unproccessable_entity",
+                      "message": "param is missing or the value is empty: asset"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10014,8 +10134,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "assets_updated": 100
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "assets_updated": 100
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/assets_updated_put_response_schema"
@@ -10027,7 +10151,9 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10613,67 +10739,71 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "assets": [
-                    {
-                      "id": 183,
-                      "created_at": "2015-08-06T12:37:54Z",
-                      "last_seen_time": "2015-08-12T15:00:54Z",
-                      "operating_system": null,
-                      "last_booted_at": null,
-                      "ipv6": null,
-                      "locator": "http://www.example.com",
-                      "primary_locator": "url",
-                      "network_ports": {
-                        "id": 600002,
-                        "protocol": "TCP",
-                        "port_number": 8080,
-                        "name": "http",
-                        "product": "tomcat",
-                        "version": "7.0.61",
-                        "state": "running",
-                        "ostype": "windows"
-                      },
-                      "tags": [
-                        "nihil",
-                        "facilis",
-                        "quo"
-                      ],
-                      "vulnerabilities_count": 1,
-                      "inactive_at": "2020-10-31",
-                      "status_set_manually": false,
-                      "overage": false,
-                      "urls": {
-                        "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
-                      },
-                      "notes": null,
-                      "priority": 1,
-                      "hostname": null,
-                      "mac_address": null,
-                      "ec2": null,
-                      "external_id": null,
-                      "netbios": null,
-                      "fqdn": null,
-                      "ip_address": "127.0.0.1",
-                      "url": null,
-                      "file": null,
-                      "database": null,
-                      "application": null,
-                      "risk_meter_score": 0,
-                      "asset_groups": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "assets": [
                         {
-                          "id": 1,
-                          "name": "name"
+                          "id": 183,
+                          "created_at": "2015-08-06T12:37:54Z",
+                          "last_seen_time": "2015-08-12T15:00:54Z",
+                          "operating_system": null,
+                          "last_booted_at": null,
+                          "ipv6": null,
+                          "locator": "http://www.example.com",
+                          "primary_locator": "url",
+                          "network_ports": {
+                            "id": 600002,
+                            "protocol": "TCP",
+                            "port_number": 8080,
+                            "name": "http",
+                            "product": "tomcat",
+                            "version": "7.0.61",
+                            "state": "running",
+                            "ostype": "windows"
+                          },
+                          "tags": [
+                            "nihil",
+                            "facilis",
+                            "quo"
+                          ],
+                          "vulnerabilities_count": 1,
+                          "inactive_at": "2020-10-31",
+                          "status_set_manually": false,
+                          "overage": false,
+                          "urls": {
+                            "vulnerabilities": "https://api.kennasecurity.com/assets/183/vulnerabilities"
+                          },
+                          "notes": null,
+                          "priority": 1,
+                          "hostname": null,
+                          "mac_address": null,
+                          "ec2": null,
+                          "external_id": null,
+                          "netbios": null,
+                          "fqdn": null,
+                          "ip_address": "127.0.0.1",
+                          "url": null,
+                          "file": null,
+                          "database": null,
+                          "application": null,
+                          "risk_meter_score": 0,
+                          "asset_groups": [
+                            {
+                              "id": 1,
+                              "name": "name"
+                            }
+                          ],
+                          "status": "active",
+                          "owner": "Freddy"
                         }
                       ],
-                      "status": "active",
-                      "owner": "Freddy"
+                      "meta": {
+                        "total_count": 800,
+                        "page": 1,
+                        "pages": 2
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 800,
-                    "page": 1,
-                    "pages": 2
                   }
                 },
                 "schema": {
@@ -10697,7 +10827,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10791,10 +10923,14 @@
             "description": "422",
             "content": {
               "application/gzip": {
-                "example": {
-                  "success": "false",
-                  "error": "unprocessable_entity",
-                  "message": "end_date must be one full day before the current date UTC"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "unprocessable_entity",
+                      "message": "end_date must be one full day before the current date UTC"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10825,8 +10961,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "Client report refresh running"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "Client report refresh running"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/message_response_schema"
@@ -10838,7 +10978,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10869,8 +11011,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "Client report refresh started"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "Client report refresh started"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/message_response_schema"
@@ -10882,7 +11028,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10894,10 +11042,14 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
-                  "error": "unprocessable_entity",
-                  "message": "There is currently a client report refresh running",
-                  "success": "false"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "error": "unprocessable_entity",
+                      "message": "There is currently a client report refresh running",
+                      "success": "false"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -10948,25 +11100,29 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 123456,
-                  "start_time": "2020-02-02T03:34:01.000Z",
-                  "end_time": "2020-02-02T03:34:08.000Z",
-                  "success": true,
-                  "total_payload_count": 0,
-                  "processed_payload_count": 0,
-                  "failed_payload_count": 0,
-                  "processed_assets_count": 0,
-                  "assets_with_tags_reset_count": 0,
-                  "processed_scanner_vuln_count": 0,
-                  "updated_scanner_vuln_count": 0,
-                  "created_scanner_vuln_count": 0,
-                  "closed_scanner_vuln_count": 0,
-                  "autoclosed_scanner_vuln_count": 0,
-                  "reopened_scanner_vuln_count": 0,
-                  "closed_vuln_count": 0,
-                  "autoclosed_vuln_count": 0,
-                  "reopened_vuln_count": 0
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 123456,
+                      "start_time": "2020-02-02T03:34:01.000Z",
+                      "end_time": "2020-02-02T03:34:08.000Z",
+                      "success": true,
+                      "total_payload_count": 0,
+                      "processed_payload_count": 0,
+                      "failed_payload_count": 0,
+                      "processed_assets_count": 0,
+                      "assets_with_tags_reset_count": 0,
+                      "processed_scanner_vuln_count": 0,
+                      "updated_scanner_vuln_count": 0,
+                      "created_scanner_vuln_count": 0,
+                      "closed_scanner_vuln_count": 0,
+                      "autoclosed_scanner_vuln_count": 0,
+                      "reopened_scanner_vuln_count": 0,
+                      "closed_vuln_count": 0,
+                      "autoclosed_vuln_count": 0,
+                      "reopened_vuln_count": 0
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/connector_run_status_schema"
@@ -10978,7 +11134,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11020,8 +11178,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "success": true
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": true
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/success_put_response_schema"
@@ -11075,28 +11237,32 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": [
-                  {
-                    "id": 1,
-                    "start_time": "2020-02-02T03:34:01.000Z",
-                    "end_time": "2020-02-02T03:34:08.000Z",
-                    "success": true,
-                    "total_payload_count": 0,
-                    "processed_payload_count": 0,
-                    "failed_payload_count": 0,
-                    "processed_assets_count": 0,
-                    "assets_with_tags_reset_count": 0,
-                    "processed_scanner_vuln_count": 0,
-                    "updated_scanner_vuln_count": 0,
-                    "created_scanner_vuln_count": 0,
-                    "closed_scanner_vuln_count": 0,
-                    "autoclosed_scanner_vuln_count": 0,
-                    "reopened_scanner_vuln_count": 0,
-                    "closed_vuln_count": 0,
-                    "autoclosed_vuln_count": 0,
-                    "reopened_vuln_count": 0
+                "examples": {
+                  "example_0": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "start_time": "2020-02-02T03:34:01.000Z",
+                        "end_time": "2020-02-02T03:34:08.000Z",
+                        "success": true,
+                        "total_payload_count": 0,
+                        "processed_payload_count": 0,
+                        "failed_payload_count": 0,
+                        "processed_assets_count": 0,
+                        "assets_with_tags_reset_count": 0,
+                        "processed_scanner_vuln_count": 0,
+                        "updated_scanner_vuln_count": 0,
+                        "created_scanner_vuln_count": 0,
+                        "closed_scanner_vuln_count": 0,
+                        "autoclosed_scanner_vuln_count": 0,
+                        "reopened_scanner_vuln_count": 0,
+                        "closed_vuln_count": 0,
+                        "autoclosed_vuln_count": 0,
+                        "reopened_vuln_count": 0
+                      }
+                    ]
                   }
-                ],
+                },
                 "schema": {
                   "type": "array",
                   "items": {
@@ -11110,10 +11276,14 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
-                  "success": false,
-                  "error": "not_found",
-                  "message": "Connector was not found."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": false,
+                      "error": "not_found",
+                      "message": "Connector was not found."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11156,17 +11326,21 @@
             "description": "With run as `false` and run as `true`",
             "content": {
               "application/json": {
-                "example": [
-                  {
-                    "success": "true",
-                    "connector_run_id": 16180
-                  },
-                  {
-                    "success": "true",
-                    "run_url": "https://api.kennasecurity.com/connectors/155304/run",
-                    "data_file": 18878368
+                "examples": {
+                  "example_0": {
+                    "value": [
+                      {
+                        "success": "true",
+                        "connector_run_id": 16180
+                      },
+                      {
+                        "success": "true",
+                        "run_url": "https://api.kennasecurity.com/connectors/155304/run",
+                        "data_file": 18878368
+                      }
+                    ]
                   }
-                ],
+                },
                 "schema": {
                   "oneOf": [
                     {
@@ -11184,10 +11358,14 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "bad request",
-                  "message": "unexpected token"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "bad request",
+                      "message": "unexpected token"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11199,10 +11377,14 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "Unprocessable_entity",
-                  "message": "HttpError"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "Unprocessable_entity",
+                      "message": "HttpError"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11264,9 +11446,13 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "success": true,
-                  "connector_run_id": 123
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": true,
+                      "connector_run_id": 123
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/success_run_get_response_schema"
@@ -11278,7 +11464,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11309,21 +11497,25 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "connectors": [
-                    {
-                      "host": null,
-                      "name": "QualysGuard",
-                      "running": false,
-                      "id": 1
-                    },
-                    {
-                      "host": "test.example.com",
-                      "name": "JIRA",
-                      "running": false,
-                      "id": 3
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "connectors": [
+                        {
+                          "host": null,
+                          "name": "QualysGuard",
+                          "running": false,
+                          "id": 1
+                        },
+                        {
+                          "host": "test.example.com",
+                          "name": "JIRA",
+                          "running": false,
+                          "id": 3
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "type": "object",
@@ -11340,7 +11532,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11385,7 +11579,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11425,26 +11621,30 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "dashboard_group": {
-                    "id": 34008,
-                    "name": "API-8",
-                    "asset_search_ids": [
-                      145692,
-                      145490
-                    ],
-                    "asset_search_order": "default",
-                    "client_id": 22226,
-                    "order": null,
-                    "user_id": 245244,
-                    "created_at": "2019-12-02T23:27:27.000Z",
-                    "updated_at": "2019-12-02T23:27:27.000Z",
-                    "editable": true,
-                    "starred": false,
-                    "share_method": "roles",
-                    "role_ids": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "dashboard_group": {
+                        "id": 34008,
+                        "name": "API-8",
+                        "asset_search_ids": [
+                          145692,
+                          145490
+                        ],
+                        "asset_search_order": "default",
+                        "client_id": 22226,
+                        "order": null,
+                        "user_id": 245244,
+                        "created_at": "2019-12-02T23:27:27.000Z",
+                        "updated_at": "2019-12-02T23:27:27.000Z",
+                        "editable": true,
+                        "starred": false,
+                        "share_method": "roles",
+                        "role_ids": [
 
-                    ]
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -11457,7 +11657,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11497,24 +11699,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 33931,
-                  "name": "api test 1",
-                  "asset_search_ids": [
-                    112112
-                  ],
-                  "asset_search_order": "default",
-                  "client_id": 22226,
-                  "order": 1,
-                  "user_id": 245244,
-                  "created_at": "2019-10-05T19:39:21.000Z",
-                  "updated_at": "2019-11-05T10:48:14.000Z",
-                  "editable": true,
-                  "starred": false,
-                  "share_method": "roles",
-                  "role_ids": [
-                    12014
-                  ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 33931,
+                      "name": "api test 1",
+                      "asset_search_ids": [
+                        112112
+                      ],
+                      "asset_search_order": "default",
+                      "client_id": 22226,
+                      "order": 1,
+                      "user_id": 245244,
+                      "created_at": "2019-10-05T19:39:21.000Z",
+                      "updated_at": "2019-11-05T10:48:14.000Z",
+                      "editable": true,
+                      "starred": false,
+                      "share_method": "roles",
+                      "role_ids": [
+                        12014
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/id_put_response_schema"
@@ -11526,7 +11732,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11566,97 +11774,101 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "dashboard_groups": [
-                    {
-                      "id": 33931,
-                      "name": "First",
-                      "asset_search_ids": [
-                        145491,
-                        145490,
-                        145489
-                      ],
-                      "asset_search_order": "default",
-                      "client_id": 22226,
-                      "order": 1,
-                      "user_id": 245244,
-                      "created_at": "2019-10-05T19:39:21.000Z",
-                      "updated_at": "2019-11-05T10:48:14.000Z",
-                      "editable": true,
-                      "starred": false,
-                      "share_method": "not_shared",
-                      "role_ids": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "dashboard_groups": [
+                        {
+                          "id": 33931,
+                          "name": "First",
+                          "asset_search_ids": [
+                            145491,
+                            145490,
+                            145489
+                          ],
+                          "asset_search_order": "default",
+                          "client_id": 22226,
+                          "order": 1,
+                          "user_id": 245244,
+                          "created_at": "2019-10-05T19:39:21.000Z",
+                          "updated_at": "2019-11-05T10:48:14.000Z",
+                          "editable": true,
+                          "starred": false,
+                          "share_method": "not_shared",
+                          "role_ids": [
 
-                      ]
-                    },
-                    {
-                      "id": 33933,
-                      "name": "FIRST",
-                      "asset_search_ids": [
-                        145487,
-                        145491,
-                        145490,
-                        145489,
-                        145691
-                      ],
-                      "asset_search_order": "default",
-                      "client_id": 22226,
-                      "order": 1,
-                      "user_id": 245244,
-                      "created_at": "2019-10-05T19:42:12.000Z",
-                      "updated_at": "2019-11-20T23:06:34.000Z",
-                      "editable": true,
-                      "starred": false,
-                      "share_method": "roles",
-                      "role_ids": [
-                        12016
-                      ]
-                    },
-                    {
-                      "id": 33934,
-                      "name": "SECOND",
-                      "asset_search_ids": [
-                        145489,
-                        145490,
-                        145487,
-                        145491
-                      ],
-                      "asset_search_order": "default",
-                      "client_id": 22226,
-                      "order": 2,
-                      "user_id": 245244,
-                      "created_at": "2019-10-05T19:42:34.000Z",
-                      "updated_at": "2019-10-29T18:49:01.000Z",
-                      "editable": true,
-                      "starred": false,
-                      "share_method": "not_shared",
-                      "role_ids": [
+                          ]
+                        },
+                        {
+                          "id": 33933,
+                          "name": "FIRST",
+                          "asset_search_ids": [
+                            145487,
+                            145491,
+                            145490,
+                            145489,
+                            145691
+                          ],
+                          "asset_search_order": "default",
+                          "client_id": 22226,
+                          "order": 1,
+                          "user_id": 245244,
+                          "created_at": "2019-10-05T19:42:12.000Z",
+                          "updated_at": "2019-11-20T23:06:34.000Z",
+                          "editable": true,
+                          "starred": false,
+                          "share_method": "roles",
+                          "role_ids": [
+                            12016
+                          ]
+                        },
+                        {
+                          "id": 33934,
+                          "name": "SECOND",
+                          "asset_search_ids": [
+                            145489,
+                            145490,
+                            145487,
+                            145491
+                          ],
+                          "asset_search_order": "default",
+                          "client_id": 22226,
+                          "order": 2,
+                          "user_id": 245244,
+                          "created_at": "2019-10-05T19:42:34.000Z",
+                          "updated_at": "2019-10-29T18:49:01.000Z",
+                          "editable": true,
+                          "starred": false,
+                          "share_method": "not_shared",
+                          "role_ids": [
 
-                      ]
-                    },
-                    {
-                      "id": 33935,
-                      "name": "THIRD",
-                      "asset_search_ids": [
-                        145487,
-                        145663,
-                        145490,
-                        145555
-                      ],
-                      "asset_search_order": "default",
-                      "client_id": 22226,
-                      "order": 3,
-                      "user_id": 245244,
-                      "created_at": "2019-10-05T19:43:42.000Z",
-                      "updated_at": "2019-11-05T10:09:27.000Z",
-                      "editable": true,
-                      "starred": false,
-                      "share_method": "not_shared",
-                      "role_ids": [
+                          ]
+                        },
+                        {
+                          "id": 33935,
+                          "name": "THIRD",
+                          "asset_search_ids": [
+                            145487,
+                            145663,
+                            145490,
+                            145555
+                          ],
+                          "asset_search_order": "default",
+                          "client_id": 22226,
+                          "order": 3,
+                          "user_id": 245244,
+                          "created_at": "2019-10-05T19:43:42.000Z",
+                          "updated_at": "2019-11-05T10:09:27.000Z",
+                          "editable": true,
+                          "starred": false,
+                          "share_method": "not_shared",
+                          "role_ids": [
 
+                          ]
+                        }
                       ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/dashboard_groups_get_response_schema"
@@ -11668,7 +11880,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11700,24 +11914,28 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": 33931,
-                  "name": "api test 1",
-                  "asset_search_ids": [
-                    112112
-                  ],
-                  "asset_search_order": "default",
-                  "client_id": 22226,
-                  "order": 1,
-                  "user_id": 245244,
-                  "created_at": "2019-10-05T19:39:21.000Z",
-                  "updated_at": "2019-11-05T10:48:14.000Z",
-                  "editable": true,
-                  "starred": false,
-                  "share_method": "roles",
-                  "role_ids": [
-                    12014
-                  ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 33931,
+                      "name": "api test 1",
+                      "asset_search_ids": [
+                        112112
+                      ],
+                      "asset_search_order": "default",
+                      "client_id": 22226,
+                      "order": 1,
+                      "user_id": 245244,
+                      "created_at": "2019-10-05T19:39:21.000Z",
+                      "updated_at": "2019-11-05T10:48:14.000Z",
+                      "editable": true,
+                      "starred": false,
+                      "share_method": "roles",
+                      "role_ids": [
+                        12014
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/dashboard_groups_post_response_schema"
@@ -11729,7 +11947,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11780,61 +12000,65 @@
             "description": "200",
             "content": {
               "application/gzip": {
-                "example": {
-                  "assets": [
-                    {
-                      "vulnerabilities_count": 1,
-                      "notes": null,
-                      "last_booted_at": null,
-                      "created_at": "2013-09-24T15:50:21Z",
-                      "primary_locator": "url",
-                      "network_ports": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "assets": [
                         {
+                          "vulnerabilities_count": 1,
+                          "notes": null,
+                          "last_booted_at": null,
+                          "created_at": "2013-09-24T15:50:21Z",
+                          "primary_locator": "url",
+                          "network_ports": [
+                            {
+                              "hostname": null,
+                              "product": "tomcat",
+                              "protocol": "TCP",
+                              "extra_info": null,
+                              "port_number": 8080,
+                              "name": "http",
+                              "id": 600002,
+                              "ostype": "windows",
+                              "state": "running",
+                              "version": "7.0.61"
+                            }
+                          ],
+                          "ipv6": null,
+                          "operating_system": null,
+                          "id": 183,
+                          "last_seen_time": "2013-09-30T20:00:30Z",
+                          "owner": null,
+                          "priority": 1,
+                          "tags": [
+                            "nihil",
+                            "facilis",
+                            "quo"
+                          ],
+                          "locator": "http://www.example.com",
+                          "status": "active",
+                          "urls": {
+                            "vulnerabilities": "api.kennasec.com/assets/183/vulnerabilities"
+                          },
+                          "application": null,
+                          "external_id": null,
+                          "ec2": null,
+                          "url": null,
+                          "netbios": null,
+                          "file": null,
+                          "fqdn": null,
                           "hostname": null,
-                          "product": "tomcat",
-                          "protocol": "TCP",
-                          "extra_info": null,
-                          "port_number": 8080,
-                          "name": "http",
-                          "id": 600002,
-                          "ostype": "windows",
-                          "state": "running",
-                          "version": "7.0.61"
+                          "database": null,
+                          "ip_address": "127.0.0.1",
+                          "mac_address": null,
+                          "risk_meter_score": 0,
+                          "overage": false
                         }
                       ],
-                      "ipv6": null,
-                      "operating_system": null,
-                      "id": 183,
-                      "last_seen_time": "2013-09-30T20:00:30Z",
-                      "owner": null,
-                      "priority": 1,
-                      "tags": [
-                        "nihil",
-                        "facilis",
-                        "quo"
-                      ],
-                      "locator": "http://www.example.com",
-                      "status": "active",
-                      "urls": {
-                        "vulnerabilities": "api.kennasec.com/assets/183/vulnerabilities"
-                      },
-                      "application": null,
-                      "external_id": null,
-                      "ec2": null,
-                      "url": null,
-                      "netbios": null,
-                      "file": null,
-                      "fqdn": null,
-                      "hostname": null,
-                      "database": null,
-                      "ip_address": "127.0.0.1",
-                      "mac_address": null,
-                      "risk_meter_score": 0,
-                      "overage": false
+                      "meta": {
+                        "total_count": 900
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 900
                   }
                 },
                 "schema": {
@@ -11910,9 +12134,13 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "search_id": 42,
-                  "record_count": 2001
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "search_id": 42,
+                      "record_count": 2001
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/search_id_post_response_schema"
@@ -11924,7 +12152,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -11936,10 +12166,14 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
-                  "search_id": 1,
-                  "record_count": 94,
-                  "error_message": "A duplicate export exists that has not processed."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "search_id": 1,
+                      "record_count": 94,
+                      "error_message": "A duplicate export exists that has not processed."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/search_id_post_422_response_schema"
@@ -11990,8 +12224,12 @@
             "description": "Export complete",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "Export ready for download"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "Export ready for download"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/export_status_get_response_schema"
@@ -12003,8 +12241,12 @@
             "description": "Export not complete",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "The export is currently processing. Try again later."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "The export is currently processing. Try again later."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/export_status_get_response_schema"
@@ -12016,8 +12258,12 @@
             "description": "Cannot find a search",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "No search found"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "No search found"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -12029,8 +12275,12 @@
             "description": "Expired search",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "The search has expired and is no longer available."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "The search has expired and is no longer available."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -12042,8 +12292,12 @@
             "description": "Unexpected error",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "There was an error getting your search data. Please contact tech support for more details."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "There was an error getting your search data. Please contact tech support for more details."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -12094,8 +12348,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "message": "Terminating client data export."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "message": "Terminating client data export."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/message_put_response_schema"
@@ -12107,10 +12365,55 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entitlements/overage": {
+      "get": {
+        "summary": "Get Overage Status",
+        "description": "<p>Returns the client entitlements overage status.</p><p></p><p>",
+        "operationId": "entitlements-overage",
+        "security": [
+          {
+            "X-Risk-Token": [
+
+            ]
+          }
+        ],
+        "tags": [
+          "ENTITLEMENTS"
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "overage_status": false
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "overage_status": {
+                      "type": "boolean",
+                      "example": "false",
+                      "description": "Indicates if the client is in overage."
+                    }
+                  }
                 }
               }
             }
@@ -12149,32 +12452,36 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "finding": {
-                    "application_locator": "application_locator_2",
-                    "asset_id": 123,
-                    "closed_at": null,
-                    "connector": {
-                      "id": 789,
-                      "name": "API"
-                    },
-                    "created_at": "2020-06-16T19:45:29.000Z",
-                    "due_date": "2020-06-17T00:00:00.000Z",
-                    "external_unique_id": "3287238723",
-                    "file_locator": "file.js",
-                    "id": 1,
-                    "identifiers": [
-                      "CWE-242"
-                    ],
-                    "last_found_on": "2020-06-15T12:28:10.000Z",
-                    "score": 80,
-                    "status": "in_progress",
-                    "updated_at": "2020-06-16T19:45:29.000Z",
-                    "url_locator": null,
-                    "vulnerability_definition": {
-                      "description": "The program calls a function that can never be guaranteed to work safely.",
-                      "id": 12345,
-                      "name": "CWE 242 - Use of Inherently Dangerous Function"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "finding": {
+                        "application_locator": "application_locator_2",
+                        "asset_id": 123,
+                        "closed_at": null,
+                        "connector": {
+                          "id": 789,
+                          "name": "API"
+                        },
+                        "created_at": "2020-06-16T19:45:29.000Z",
+                        "due_date": "2020-06-17T00:00:00.000Z",
+                        "external_unique_id": "3287238723",
+                        "file_locator": "file.js",
+                        "id": 1,
+                        "identifiers": [
+                          "CWE-242"
+                        ],
+                        "last_found_on": "2020-06-15T12:28:10.000Z",
+                        "score": 80,
+                        "status": "in_progress",
+                        "updated_at": "2020-06-16T19:45:29.000Z",
+                        "url_locator": null,
+                        "vulnerability_definition": {
+                          "description": "The program calls a function that can never be guaranteed to work safely.",
+                          "id": 12345,
+                          "name": "CWE 242 - Use of Inherently Dangerous Function"
+                        }
+                      }
                     }
                   }
                 },
@@ -12216,32 +12523,36 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "finding": {
-                    "application_locator": "application_locator_2",
-                    "asset_id": 123,
-                    "closed_at": "2020-07-21T00:00:00.000Z",
-                    "connector": {
-                      "id": 789,
-                      "name": "API"
-                    },
-                    "created_at": "2020-06-16T19:45:29.000Z",
-                    "due_date": "2020-06-17T00:00:00.000Z",
-                    "external_unique_id": "3287238723",
-                    "file_locator": "file.js",
-                    "id": 1,
-                    "identifiers": [
-                      "CWE-242"
-                    ],
-                    "last_found_on": "2020-06-15T12:28:10.000Z",
-                    "score": 80,
-                    "status": "resolved",
-                    "updated_at": "2020-06-16T19:45:29.000Z",
-                    "url_locator": null,
-                    "vulnerability_definition": {
-                      "description": "The program calls a function that can never be guaranteed to work safely.",
-                      "id": 12345,
-                      "name": "CWE 242 - Use of Inherently Dangerous Function"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "finding": {
+                        "application_locator": "application_locator_2",
+                        "asset_id": 123,
+                        "closed_at": "2020-07-21T00:00:00.000Z",
+                        "connector": {
+                          "id": 789,
+                          "name": "API"
+                        },
+                        "created_at": "2020-06-16T19:45:29.000Z",
+                        "due_date": "2020-06-17T00:00:00.000Z",
+                        "external_unique_id": "3287238723",
+                        "file_locator": "file.js",
+                        "id": 1,
+                        "identifiers": [
+                          "CWE-242"
+                        ],
+                        "last_found_on": "2020-06-15T12:28:10.000Z",
+                        "score": 80,
+                        "status": "resolved",
+                        "updated_at": "2020-06-16T19:45:29.000Z",
+                        "url_locator": null,
+                        "vulnerability_definition": {
+                          "description": "The program calls a function that can never be guaranteed to work safely.",
+                          "id": 12345,
+                          "name": "CWE 242 - Use of Inherently Dangerous Function"
+                        }
+                      }
                     }
                   }
                 },
@@ -12297,8 +12608,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "findings_deleted": 3
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "findings_deleted": 3
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/findings_deleted_delete_response_schema"
@@ -12485,40 +12800,44 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "findings": [
-                    {
-                      "application_locator": "application_locator_2",
-                      "asset_id": 123,
-                      "closed_at": null,
-                      "connector": {
-                        "id": 789,
-                        "name": "API"
-                      },
-                      "created_at": "2020-06-16T19:45:29.000Z",
-                      "due_date": "2020-06-17T00:00:00.000Z",
-                      "external_unique_id": "3287238723",
-                      "file_locator": "file.js",
-                      "id": 1,
-                      "identifiers": [
-                        "CWE-242"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "findings": [
+                        {
+                          "application_locator": "application_locator_2",
+                          "asset_id": 123,
+                          "closed_at": null,
+                          "connector": {
+                            "id": 789,
+                            "name": "API"
+                          },
+                          "created_at": "2020-06-16T19:45:29.000Z",
+                          "due_date": "2020-06-17T00:00:00.000Z",
+                          "external_unique_id": "3287238723",
+                          "file_locator": "file.js",
+                          "id": 1,
+                          "identifiers": [
+                            "CWE-242"
+                          ],
+                          "last_found_on": "2020-06-15T12:28:10.000Z",
+                          "score": 80,
+                          "status": "in_progress",
+                          "updated_at": "2020-06-16T19:45:29.000Z",
+                          "url_locator": null,
+                          "vulnerability_definition": {
+                            "description": "The program calls a function that can never be guaranteed to work safely.",
+                            "id": 12345,
+                            "name": "CWE 242 - Use of Inherently Dangerous Function"
+                          }
+                        }
                       ],
-                      "last_found_on": "2020-06-15T12:28:10.000Z",
-                      "score": 80,
-                      "status": "in_progress",
-                      "updated_at": "2020-06-16T19:45:29.000Z",
-                      "url_locator": null,
-                      "vulnerability_definition": {
-                        "description": "The program calls a function that can never be guaranteed to work safely.",
-                        "id": 12345,
-                        "name": "CWE 242 - Use of Inherently Dangerous Function"
+                      "meta": {
+                        "page": 1,
+                        "pages": 5,
+                        "total_count": 421
                       }
                     }
-                  ],
-                  "meta": {
-                    "page": 1,
-                    "pages": 5,
-                    "total_count": 421
                   }
                 },
                 "schema": {
@@ -12551,32 +12870,36 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "finding": {
-                    "application_locator": "application_locator_2",
-                    "asset_id": 123,
-                    "closed_at": null,
-                    "connector": {
-                      "id": 789,
-                      "name": "API"
-                    },
-                    "created_at": "2020-06-16T19:45:29.000Z",
-                    "due_date": "2020-06-17T00:00:00.000Z",
-                    "external_unique_id": "3287238723",
-                    "file_locator": "file.js",
-                    "id": 1,
-                    "identifiers": [
-                      "CWE-242"
-                    ],
-                    "last_found_on": "2020-06-15T12:28:10.000Z",
-                    "score": 80,
-                    "status": "in_progress",
-                    "updated_at": "2020-06-16T19:45:29.000Z",
-                    "url_locator": null,
-                    "vulnerability_definition": {
-                      "description": "The program calls a function that can never be guaranteed to work safely.",
-                      "id": 12345,
-                      "name": "CWE 242 - Use of Inherently Dangerous Function"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "finding": {
+                        "application_locator": "application_locator_2",
+                        "asset_id": 123,
+                        "closed_at": null,
+                        "connector": {
+                          "id": 789,
+                          "name": "API"
+                        },
+                        "created_at": "2020-06-16T19:45:29.000Z",
+                        "due_date": "2020-06-17T00:00:00.000Z",
+                        "external_unique_id": "3287238723",
+                        "file_locator": "file.js",
+                        "id": 1,
+                        "identifiers": [
+                          "CWE-242"
+                        ],
+                        "last_found_on": "2020-06-15T12:28:10.000Z",
+                        "score": 80,
+                        "status": "in_progress",
+                        "updated_at": "2020-06-16T19:45:29.000Z",
+                        "url_locator": null,
+                        "vulnerability_definition": {
+                          "description": "The program calls a function that can never be guaranteed to work safely.",
+                          "id": 12345,
+                          "name": "CWE 242 - Use of Inherently Dangerous Function"
+                        }
+                      }
                     }
                   }
                 },
@@ -12629,39 +12952,43 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "fix": {
-                    "id": "48910",
-                    "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                    "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
-                    "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                    "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                    "urls": [
-                      "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
-                    ],
-                    "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                    "vendor": "oracle",
-                    "assets": [
-                      {
-                        "id": 555,
-                        "locator": "127.0.0.1",
-                        "primary_locator": "ip_address",
-                        "display_locator": "localhost"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "fix": {
+                        "id": "48910",
+                        "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                        "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
+                        "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                        "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                        "urls": [
+                          "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
+                        ],
+                        "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                        "vendor": "oracle",
+                        "assets": [
+                          {
+                            "id": 555,
+                            "locator": "127.0.0.1",
+                            "primary_locator": "ip_address",
+                            "display_locator": "localhost"
+                          }
+                        ],
+                        "scanner_ids": [
+                          1
+                        ],
+                        "cves": [
+                          "CVE-2006-4924",
+                          "CVE-2006-5051"
+                        ],
+                        "updated_at": "5/19/2015",
+                        "patch_publication_date": "4/21/2009",
+                        "category": "Ubuntu",
+                        "vuln_count": 1,
+                        "max_vuln_score": 49.0
                       }
-                    ],
-                    "scanner_ids": [
-                      1
-                    ],
-                    "cves": [
-                      "CVE-2006-4924",
-                      "CVE-2006-5051"
-                    ],
-                    "updated_at": "5/19/2015",
-                    "patch_publication_date": "4/21/2009",
-                    "category": "Ubuntu",
-                    "vuln_count": 1,
-                    "max_vuln_score": 49.0
+                    }
                   }
                 },
                 "schema": {
@@ -12679,7 +13006,9 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -12721,46 +13050,50 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "fixes": [
-                    {
-                      "id": "48910",
-                      "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                      "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
-                      "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                      "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "urls": [
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
-                      ],
-                      "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                      "vendor": "oracle",
-                      "assets": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "fixes": [
                         {
-                          "id": 555,
-                          "locator": "127.0.0.1",
-                          "primary_locator": "ip_address",
-                          "display_locator": "localhost"
+                          "id": "48910",
+                          "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                          "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
+                          "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                          "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "urls": [
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
+                          ],
+                          "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                          "vendor": "oracle",
+                          "assets": [
+                            {
+                              "id": 555,
+                              "locator": "127.0.0.1",
+                              "primary_locator": "ip_address",
+                              "display_locator": "localhost"
+                            }
+                          ],
+                          "scanner_ids": [
+                            1
+                          ],
+                          "cves": [
+                            "CVE-2006-4924",
+                            "CVE-2006-5051"
+                          ],
+                          "updated_at": "5/19/2015",
+                          "patch_publication_date": "4/21/2009",
+                          "category": "Ubuntu",
+                          "vuln_count": 1,
+                          "max_vuln_score": 49.0
                         }
                       ],
-                      "scanner_ids": [
-                        1
-                      ],
-                      "cves": [
-                        "CVE-2006-4924",
-                        "CVE-2006-5051"
-                      ],
-                      "updated_at": "5/19/2015",
-                      "patch_publication_date": "4/21/2009",
-                      "category": "Ubuntu",
-                      "vuln_count": 1,
-                      "max_vuln_score": 49.0
+                      "meta": {
+                        "total_count": 32,
+                        "page": 1,
+                        "pages": 4
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 32,
-                    "page": 1,
-                    "pages": 4
                   }
                 },
                 "schema": {
@@ -12784,7 +13117,9 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -12835,46 +13170,50 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "fixes": [
-                    {
-                      "id": "48910",
-                      "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                      "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
-                      "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                      "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "urls": [
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
-                      ],
-                      "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                      "vendor": "oracle",
-                      "assets": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "fixes": [
                         {
-                          "id": 555,
-                          "locator": "127.0.0.1",
-                          "primary_locator": "ip_address",
-                          "display_locator": "localhost"
+                          "id": "48910",
+                          "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                          "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
+                          "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                          "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "urls": [
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
+                          ],
+                          "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                          "vendor": "oracle",
+                          "assets": [
+                            {
+                              "id": 555,
+                              "locator": "127.0.0.1",
+                              "primary_locator": "ip_address",
+                              "display_locator": "localhost"
+                            }
+                          ],
+                          "scanner_ids": [
+                            1
+                          ],
+                          "cves": [
+                            "CVE-2006-4924",
+                            "CVE-2006-5051"
+                          ],
+                          "updated_at": "5/19/2015",
+                          "patch_publication_date": "4/21/2009",
+                          "category": "Ubuntu",
+                          "vuln_count": 1,
+                          "max_vuln_score": 49.0
                         }
                       ],
-                      "scanner_ids": [
-                        1
-                      ],
-                      "cves": [
-                        "CVE-2006-4924",
-                        "CVE-2006-5051"
-                      ],
-                      "updated_at": "5/19/2015",
-                      "patch_publication_date": "4/21/2009",
-                      "category": "Ubuntu",
-                      "vuln_count": 1,
-                      "max_vuln_score": 49.0
+                      "meta": {
+                        "total_count": 34,
+                        "page": 1,
+                        "pages": 4
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 34,
-                    "page": 1,
-                    "pages": 4
                   }
                 },
                 "schema": {
@@ -13146,46 +13485,50 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "fixes": [
-                    {
-                      "id": "48910",
-                      "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
-                      "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
-                      "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
-                      "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                      "urls": [
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
-                        "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
-                      ],
-                      "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
-                      "vendor": "oracle",
-                      "assets": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "fixes": [
                         {
-                          "id": 555,
-                          "locator": "127.0.0.1",
-                          "primary_locator": "ip_address",
-                          "display_locator": "localhost"
+                          "id": "48910",
+                          "diagnosis": "OpenSSH is OpenBSD's SSH (Secure SHell) protocol implementation. This package includes the core files ...",
+                          "consequence": "If these vulnerabilities are successfully exploited, an attacker can bypass certain security ...",
+                          "solution": "Download the patch for ELSA-2006:0697 from Oracle metalink account ...",
+                          "url": "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                          "urls": [
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/000010.html",
+                            "http://oss.oracle.com/pipermail/el-errata/2006-November/123456.html"
+                          ],
+                          "title": "Oracle Enterprise Linux Openssh security update (ELSA-2006:0697)",
+                          "vendor": "oracle",
+                          "assets": [
+                            {
+                              "id": 555,
+                              "locator": "127.0.0.1",
+                              "primary_locator": "ip_address",
+                              "display_locator": "localhost"
+                            }
+                          ],
+                          "scanner_ids": [
+                            1
+                          ],
+                          "cves": [
+                            "CVE-2006-4924",
+                            "CVE-2006-5051"
+                          ],
+                          "updated_at": "5/19/2015",
+                          "patch_publication_date": "4/21/2009",
+                          "category": "Ubuntu",
+                          "vuln_count": 1,
+                          "max_vuln_score": 49.0
                         }
                       ],
-                      "scanner_ids": [
-                        1
-                      ],
-                      "cves": [
-                        "CVE-2006-4924",
-                        "CVE-2006-5051"
-                      ],
-                      "updated_at": "5/19/2015",
-                      "patch_publication_date": "4/21/2009",
-                      "category": "Ubuntu",
-                      "vuln_count": 1,
-                      "max_vuln_score": 49.0
+                      "meta": {
+                        "total_count": 31,
+                        "page": 1,
+                        "pages": 4
+                      }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 31,
-                    "page": 1,
-                    "pages": 4
                   }
                 },
                 "schema": {
@@ -13228,172 +13571,176 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "data": {
-                    "metric_name": "sla_adherence",
-                    "last_calculated": "2022-04-19",
-                    "values": [
-                      {
-                        "date": "2022-04-07",
-                        "medium": 100,
-                        "low": 99.98,
-                        "high": 99.98,
-                        "all": 99.99
-                      },
-                      {
-                        "date": "2022-04-06",
-                        "all": 99.99,
-                        "low": 99.98,
-                        "high": 99.98,
-                        "medium": 100
-                      },
-                      {
-                        "date": "2022-04-05",
-                        "medium": 100,
-                        "low": 99.98,
-                        "high": 99.98,
-                        "all": 99.99
-                      },
-                      {
-                        "date": "2022-04-04",
-                        "medium": 100,
-                        "low": 93.75,
-                        "high": 99.98,
-                        "all": 99.99
-                      },
-                      {
-                        "date": "2022-04-03",
-                        "all": 100,
-                        "low": 99.77,
-                        "high": 100,
-                        "medium": 100
-                      },
-                      {
-                        "date": "2022-04-02",
-                        "all": 99.97,
-                        "low": 99.77,
-                        "high": 100,
-                        "medium": 99.86
-                      },
-                      {
-                        "date": "2022-04-01",
-                        "all": 99.56,
-                        "low": 100,
-                        "high": 99.59,
-                        "medium": 71.43
-                      },
-                      {
-                        "date": "2022-03-31",
-                        "all": 91.8,
-                        "high": 90.34,
-                        "medium": 91.82,
-                        "low": 93.24
-                      },
-                      {
-                        "date": "2022-03-30",
-                        "all": 97.19,
-                        "high": 98.83,
-                        "medium": 96.33,
-                        "low": 96.4
-                      },
-                      {
-                        "date": "2022-03-29",
-                        "all": 92.75,
-                        "high": 92.55,
-                        "medium": 89.85,
-                        "low": 95.84
-                      },
-                      {
-                        "date": "2022-03-28",
-                        "all": 95.56,
-                        "high": 98.38,
-                        "medium": 95.43,
-                        "low": 92.85
-                      },
-                      {
-                        "date": "2022-03-27",
-                        "all": 94.58,
-                        "high": 97.98,
-                        "medium": 92.3,
-                        "low": 93.46
-                      },
-                      {
-                        "date": "2022-03-26",
-                        "all": 90.84,
-                        "high": 88.8,
-                        "medium": 91.48,
-                        "low": 92.24
-                      },
-                      {
-                        "date": "2022-03-25",
-                        "all": 93.8,
-                        "high": 93.98,
-                        "medium": 97.97,
-                        "low": 89.46
-                      },
-                      {
-                        "date": "2022-03-14",
-                        "all": 94.8,
-                        "high": 99.82,
-                        "medium": 92.84,
-                        "low": 91.73
-                      },
-                      {
-                        "date": "2022-03-13",
-                        "all": 92.33,
-                        "high": 88.59,
-                        "medium": 97.62,
-                        "low": 90.78
-                      },
-                      {
-                        "date": "2022-03-12",
-                        "all": 94.96,
-                        "high": 99.66,
-                        "medium": 96.62,
-                        "low": 88.61
-                      },
-                      {
-                        "date": "2022-03-11",
-                        "all": 96.52,
-                        "high": 98.38,
-                        "medium": 97.07,
-                        "low": 94.11
-                      },
-                      {
-                        "date": "2022-03-10",
-                        "all": 92.72,
-                        "high": 94.06,
-                        "medium": 94.45,
-                        "low": 89.65
-                      },
-                      {
-                        "date": "2022-03-09",
-                        "all": 94.57,
-                        "high": 95.56,
-                        "low": 97.82
-                      },
-                      {
-                        "date": "2022-03-08",
-                        "all": 93.18,
-                        "high": 94.37,
-                        "medium": 93.02,
-                        "low": 92.14
-                      },
-                      {
-                        "date": "2022-03-07",
-                        "all": 95.24,
-                        "high": 100,
-                        "medium": 90.45,
-                        "low": 95.27
-                      },
-                      {
-                        "date": "2022-03-06",
-                        "all": 96.61,
-                        "high": 99.04,
-                        "medium": 96.52,
-                        "low": 94.27
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "data": {
+                        "metric_name": "sla_adherence",
+                        "last_calculated": "2022-04-19",
+                        "values": [
+                          {
+                            "date": "2022-04-07",
+                            "medium": 100,
+                            "low": 99.98,
+                            "high": 99.98,
+                            "all": 99.99
+                          },
+                          {
+                            "date": "2022-04-06",
+                            "all": 99.99,
+                            "low": 99.98,
+                            "high": 99.98,
+                            "medium": 100
+                          },
+                          {
+                            "date": "2022-04-05",
+                            "medium": 100,
+                            "low": 99.98,
+                            "high": 99.98,
+                            "all": 99.99
+                          },
+                          {
+                            "date": "2022-04-04",
+                            "medium": 100,
+                            "low": 93.75,
+                            "high": 99.98,
+                            "all": 99.99
+                          },
+                          {
+                            "date": "2022-04-03",
+                            "all": 100,
+                            "low": 99.77,
+                            "high": 100,
+                            "medium": 100
+                          },
+                          {
+                            "date": "2022-04-02",
+                            "all": 99.97,
+                            "low": 99.77,
+                            "high": 100,
+                            "medium": 99.86
+                          },
+                          {
+                            "date": "2022-04-01",
+                            "all": 99.56,
+                            "low": 100,
+                            "high": 99.59,
+                            "medium": 71.43
+                          },
+                          {
+                            "date": "2022-03-31",
+                            "all": 91.8,
+                            "high": 90.34,
+                            "medium": 91.82,
+                            "low": 93.24
+                          },
+                          {
+                            "date": "2022-03-30",
+                            "all": 97.19,
+                            "high": 98.83,
+                            "medium": 96.33,
+                            "low": 96.4
+                          },
+                          {
+                            "date": "2022-03-29",
+                            "all": 92.75,
+                            "high": 92.55,
+                            "medium": 89.85,
+                            "low": 95.84
+                          },
+                          {
+                            "date": "2022-03-28",
+                            "all": 95.56,
+                            "high": 98.38,
+                            "medium": 95.43,
+                            "low": 92.85
+                          },
+                          {
+                            "date": "2022-03-27",
+                            "all": 94.58,
+                            "high": 97.98,
+                            "medium": 92.3,
+                            "low": 93.46
+                          },
+                          {
+                            "date": "2022-03-26",
+                            "all": 90.84,
+                            "high": 88.8,
+                            "medium": 91.48,
+                            "low": 92.24
+                          },
+                          {
+                            "date": "2022-03-25",
+                            "all": 93.8,
+                            "high": 93.98,
+                            "medium": 97.97,
+                            "low": 89.46
+                          },
+                          {
+                            "date": "2022-03-14",
+                            "all": 94.8,
+                            "high": 99.82,
+                            "medium": 92.84,
+                            "low": 91.73
+                          },
+                          {
+                            "date": "2022-03-13",
+                            "all": 92.33,
+                            "high": 88.59,
+                            "medium": 97.62,
+                            "low": 90.78
+                          },
+                          {
+                            "date": "2022-03-12",
+                            "all": 94.96,
+                            "high": 99.66,
+                            "medium": 96.62,
+                            "low": 88.61
+                          },
+                          {
+                            "date": "2022-03-11",
+                            "all": 96.52,
+                            "high": 98.38,
+                            "medium": 97.07,
+                            "low": 94.11
+                          },
+                          {
+                            "date": "2022-03-10",
+                            "all": 92.72,
+                            "high": 94.06,
+                            "medium": 94.45,
+                            "low": 89.65
+                          },
+                          {
+                            "date": "2022-03-09",
+                            "all": 94.57,
+                            "high": 95.56,
+                            "low": 97.82
+                          },
+                          {
+                            "date": "2022-03-08",
+                            "all": 93.18,
+                            "high": 94.37,
+                            "medium": 93.02,
+                            "low": 92.14
+                          },
+                          {
+                            "date": "2022-03-07",
+                            "all": 95.24,
+                            "high": 100,
+                            "medium": 90.45,
+                            "low": 95.27
+                          },
+                          {
+                            "date": "2022-03-06",
+                            "all": 96.61,
+                            "high": 99.04,
+                            "medium": 96.52,
+                            "low": 94.27
+                          }
+                        ]
                       }
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -13430,71 +13777,75 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "metrics": [
-                    {
-                      "date": "2022-05-19",
-                      "client": {
-                        "all": 10.0,
-                        "critical": 10.32
-                      },
-                      "industry": {
-                        "medium": 6.0,
-                        "all": 1.0,
-                        "critical": 1.0
-                      }
-                    },
-                    {
-                      "date": "2022-05-18",
-                      "client": {
-                        "all": 10.0,
-                        "critical": 10.33
-                      },
-                      "industry": {
-                        "medium": 6.0,
-                        "all": 1.0,
-                        "critical": 1.0
-                      }
-                    },
-                    {
-                      "date": "2022-05-17",
-                      "client": {
-                        "all": 10.0,
-                        "critical": 10.33
-                      },
-                      "industry": {
-                        "medium": 6.0,
-                        "critical": 1.0,
-                        "all": 1.0
-                      }
-                    },
-                    {
-                      "date": "2022-05-16",
-                      "client": {
-                        "all": 10.0,
-                        "critical": 10.34
-                      },
-                      "industry": {
-                        "critical": 0.0,
-                        "all": 0.0,
-                        "medium": 6.0
-                      }
-                    },
-                    {
-                      "date": "2022-05-15",
-                      "client": {
-                        "all": 10.0,
-                        "critical": 10.34
-                      },
-                      "industry": {
-                        "all": 0.0,
-                        "critical": 0.0,
-                        "low": 5.0
-                      }
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "metrics": [
+                        {
+                          "date": "2022-05-19",
+                          "client": {
+                            "all": 10.0,
+                            "critical": 10.32
+                          },
+                          "industry": {
+                            "medium": 6.0,
+                            "all": 1.0,
+                            "critical": 1.0
+                          }
+                        },
+                        {
+                          "date": "2022-05-18",
+                          "client": {
+                            "all": 10.0,
+                            "critical": 10.33
+                          },
+                          "industry": {
+                            "medium": 6.0,
+                            "all": 1.0,
+                            "critical": 1.0
+                          }
+                        },
+                        {
+                          "date": "2022-05-17",
+                          "client": {
+                            "all": 10.0,
+                            "critical": 10.33
+                          },
+                          "industry": {
+                            "medium": 6.0,
+                            "critical": 1.0,
+                            "all": 1.0
+                          }
+                        },
+                        {
+                          "date": "2022-05-16",
+                          "client": {
+                            "all": 10.0,
+                            "critical": 10.34
+                          },
+                          "industry": {
+                            "critical": 0.0,
+                            "all": 0.0,
+                            "medium": 6.0
+                          }
+                        },
+                        {
+                          "date": "2022-05-15",
+                          "client": {
+                            "all": 10.0,
+                            "critical": 10.34
+                          },
+                          "industry": {
+                            "all": 0.0,
+                            "critical": 0.0,
+                            "low": 5.0
+                          }
+                        }
+                      ],
+                      "industry_name": "Credit Unions",
+                      "client_name": "Test Client"
                     }
-                  ],
-                  "industry_name": "Credit Unions",
-                  "client_name": "Test Client"
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/vulnerability_densities_get_response_schema"
@@ -13536,21 +13887,25 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "role": {
-                    "id": 267,
-                    "created_at": "2016-02-23T17:45:13Z",
-                    "updated_at": "2016-03-01T16:00:08Z",
-                    "name": "Demo",
-                    "description": "A demo role",
-                    "access_level": "write",
-                    "asset_groups": [
-                      {
-                        "id": 5317,
-                        "name": "all_3_tags"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "role": {
+                        "id": 267,
+                        "created_at": "2016-02-23T17:45:13Z",
+                        "updated_at": "2016-03-01T16:00:08Z",
+                        "name": "Demo",
+                        "description": "A demo role",
+                        "access_level": "write",
+                        "asset_groups": [
+                          {
+                            "id": 5317,
+                            "name": "all_3_tags"
+                          }
+                        ],
+                        "role_type": "custom_write"
                       }
-                    ],
-                    "role_type": "custom_write"
+                    }
                   }
                 },
                 "schema": {
@@ -13590,7 +13945,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -13635,7 +13992,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -13767,23 +14126,27 @@
             "description": "204",
             "content": {
               "application/json": {
-                "example": {
-                  "role": {
-                    "id": 2,
-                    "created_at": "2016-02-26T17:41:28Z",
-                    "updated_at": "2016-02-26T17:41:28Z",
-                    "name": "Demo",
-                    "description": "A demo role",
-                    "access_level": "read",
-                    "asset_groups": [
-                      {
-                        "id": 5317,
-                        "name": "java"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "role": {
+                        "id": 2,
+                        "created_at": "2016-02-26T17:41:28Z",
+                        "updated_at": "2016-02-26T17:41:28Z",
+                        "name": "Demo",
+                        "description": "A demo role",
+                        "access_level": "read",
+                        "asset_groups": [
+                          {
+                            "id": 5317,
+                            "name": "java"
+                          }
+                        ],
+                        "custom_permissions": [
+                          "edit_asset_notes"
+                        ]
                       }
-                    ],
-                    "custom_permissions": [
-                      "edit_asset_notes"
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -13827,43 +14190,47 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "roles": [
-                    {
-                      "id": 267,
-                      "created_at": "2016-02-23T17:45:13Z",
-                      "updated_at": "2016-03-01T16:00:08Z",
-                      "name": "Demo",
-                      "description": "A demo role",
-                      "access_level": "write",
-                      "asset_groups": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "roles": [
                         {
-                          "id": 5317,
-                          "name": "all_3_tags"
-                        }
-                      ],
-                      "role_type": "custom_write"
-                    },
-                    {
-                      "id": 101,
-                      "created_at": "2013-05-08T20:39:33Z",
-                      "updated_at": "2016-03-01T16:00:05Z",
-                      "name": "role 2",
-                      "description": "The second role",
-                      "access_level": "custom",
-                      "asset_groups": [
+                          "id": 267,
+                          "created_at": "2016-02-23T17:45:13Z",
+                          "updated_at": "2016-03-01T16:00:08Z",
+                          "name": "Demo",
+                          "description": "A demo role",
+                          "access_level": "write",
+                          "asset_groups": [
+                            {
+                              "id": 5317,
+                              "name": "all_3_tags"
+                            }
+                          ],
+                          "role_type": "custom_write"
+                        },
                         {
-                          "id": 5281,
-                          "name": "windows"
+                          "id": 101,
+                          "created_at": "2013-05-08T20:39:33Z",
+                          "updated_at": "2016-03-01T16:00:05Z",
+                          "name": "role 2",
+                          "description": "The second role",
+                          "access_level": "custom",
+                          "asset_groups": [
+                            {
+                              "id": 5281,
+                              "name": "windows"
+                            }
+                          ],
+                          "role_type": "custom_custom",
+                          "custom_permissions": [
+                            "edit_asset_notes",
+                            "edit_vulnerability_status"
+                          ]
                         }
-                      ],
-                      "role_type": "custom_custom",
-                      "custom_permissions": [
-                        "edit_asset_notes",
-                        "edit_vulnerability_status"
                       ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/roles_get_response_schema"
@@ -13900,20 +14267,24 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "role": {
-                    "id": 2,
-                    "created_at": "2016-02-26T17:41:28Z",
-                    "updated_at": "2016-02-26T17:41:28Z",
-                    "name": "Demo",
-                    "description": "A demo role",
-                    "access_level": "read",
-                    "asset_groups": [
-                      {
-                        "id": 5317,
-                        "name": "java"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "role": {
+                        "id": 2,
+                        "created_at": "2016-02-26T17:41:28Z",
+                        "updated_at": "2016-02-26T17:41:28Z",
+                        "name": "Demo",
+                        "description": "A demo role",
+                        "access_level": "read",
+                        "asset_groups": [
+                          {
+                            "id": 5317,
+                            "name": "java"
+                          }
+                        ]
                       }
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -13960,8 +14331,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "roles_updated": 4
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "roles_updated": 4
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/roles_updated_put_response_schema"
@@ -14015,89 +14390,93 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "stack_name": "Test stack",
-                  "stack_id": 1,
-                  "applications": [
-                    {
-                      "id": 284,
-                      "name": "New Application",
-                      "edit_path": "/applications/284229/edit",
-                      "overview_path": "/applications/284229",
-                      "risk_meter_score": 0,
-                      "explore_link": "/applications/explore?application=284229",
-                      "can_edit": true,
-                      "highest_scored_finding": {
-                        "name": "CWE 89",
-                        "description": "The software constructs all or part of an SQL",
-                        "score": 50,
-                        "explore_link": "/applications/findings/293"
-                      },
-                      "vuln_breakdown": {
-                        "high": 0,
-                        "medium": 0,
-                        "low": 0,
-                        "total": 0
-                      },
-                      "vuln_count": 0,
-                      "asset_count": 0,
-                      "repo_url": "",
-                      "owner": "Github",
-                      "high_risk_vuln_link": "/explore?application%5B%5D=worldpressindex"
-                    }
-                  ],
-                  "persistent_searches": [
-                    {
-                      "asset_count": 359,
-                      "child_ids": [
-                        281
-                      ],
-                      "client_id": 166,
-                      "created_at": "2021-06-14T15:39:48Z",
-                      "full_query": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "stack_name": "Test stack",
+                      "stack_id": 1,
+                      "applications": [
                         {
-                          "status": [
-                            "active"
-                          ],
-                          "vulnerability": {
-                            "port": [
-                              "443"
-                            ],
-                            "status": [
-                              "open"
-                            ]
-                          }
+                          "id": 284,
+                          "name": "New Application",
+                          "edit_path": "/applications/284229/edit",
+                          "overview_path": "/applications/284229",
+                          "risk_meter_score": 0,
+                          "explore_link": "/applications/explore?application=284229",
+                          "can_edit": true,
+                          "highest_scored_finding": {
+                            "name": "CWE 89",
+                            "description": "The software constructs all or part of an SQL",
+                            "score": 50,
+                            "explore_link": "/applications/findings/293"
+                          },
+                          "vuln_breakdown": {
+                            "high": 0,
+                            "medium": 0,
+                            "low": 0,
+                            "total": 0
+                          },
+                          "vuln_count": 0,
+                          "asset_count": 0,
+                          "repo_url": "",
+                          "owner": "Github",
+                          "high_risk_vuln_link": "/explore?application%5B%5D=worldpressindex"
                         }
                       ],
-                      "id": 280,
-                      "name": "parent port 443",
-                      "parent_id": 1,
-                      "parent": {
-                      },
-                      "querystring": "status%5B%5D=active&vulnerability%5Bport%5D%5B%5D=443&vulnerability%5Bstatus%5D%5B%5D=open",
-                      "resource": "asset",
-                      "risk_meter_score": 640,
-                      "true_risk_meter_score": 640,
-                      "updated_at": "2021-06-14T15:39:48Z",
-                      "direct_descendants": [
+                      "persistent_searches": [
                         {
-                          "id": 281,
-                          "name": "child score 66",
-                          "node_id": "cb7f8aa6-6207-4e84-bc32-7bb009f44eeb",
-                          "querystring": "status%5B%5D=active&vulnerability%5Bq%5D=vulnerability_score%3A%26gt%3B66&vulnerability%5Bstatus%5D%5B%5D=open",
-                          "risk_meter_score": 930,
-                          "asset_count": 36,
-                          "vulnerability_count": 63,
-                          "has_children": false,
+                          "asset_count": 359,
+                          "child_ids": [
+                            281
+                          ],
+                          "client_id": 166,
+                          "created_at": "2021-06-14T15:39:48Z",
+                          "full_query": [
+                            {
+                              "status": [
+                                "active"
+                              ],
+                              "vulnerability": {
+                                "port": [
+                                  "443"
+                                ],
+                                "status": [
+                                  "open"
+                                ]
+                              }
+                            }
+                          ],
+                          "id": 280,
+                          "name": "parent port 443",
+                          "parent_id": 1,
                           "parent": {
-                            "id": 280,
-                            "name": "parent port 443",
-                            "risk_meter_score": 640
-                          }
+                          },
+                          "querystring": "status%5B%5D=active&vulnerability%5Bport%5D%5B%5D=443&vulnerability%5Bstatus%5D%5B%5D=open",
+                          "resource": "asset",
+                          "risk_meter_score": 640,
+                          "true_risk_meter_score": 640,
+                          "updated_at": "2021-06-14T15:39:48Z",
+                          "direct_descendants": [
+                            {
+                              "id": 281,
+                              "name": "child score 66",
+                              "node_id": "cb7f8aa6-6207-4e84-bc32-7bb009f44eeb",
+                              "querystring": "status%5B%5D=active&vulnerability%5Bq%5D=vulnerability_score%3A%26gt%3B66&vulnerability%5Bstatus%5D%5B%5D=open",
+                              "risk_meter_score": 930,
+                              "asset_count": 36,
+                              "vulnerability_count": 63,
+                              "has_children": false,
+                              "parent": {
+                                "id": 280,
+                                "name": "parent port 443",
+                                "risk_meter_score": 640
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/stack_get_response_schema"
@@ -14109,7 +14488,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14152,7 +14533,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14192,16 +14575,20 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "stack": {
-                    "id": 1,
-                    "name": "Test stack",
-                    "application_ids": [
-                      284
-                    ],
-                    "asset_search_ids": [
-                      233
-                    ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "stack": {
+                        "id": 1,
+                        "name": "Test stack",
+                        "application_ids": [
+                          284
+                        ],
+                        "asset_search_ids": [
+                          233
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14214,7 +14601,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14265,15 +14654,19 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": "1",
-                  "application_score": {
-                    "value": 350,
-                    "difference": 350
-                  },
-                  "findings_count": {
-                    "value": 2,
-                    "difference": 2
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": "1",
+                      "application_score": {
+                        "value": 350,
+                        "difference": 350
+                      },
+                      "findings_count": {
+                        "value": 2,
+                        "difference": 2
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14286,7 +14679,9 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14328,19 +14723,23 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "id": "4",
-                  "asset_groups_score": {
-                    "value": 530,
-                    "difference": 530
-                  },
-                  "assets_count": {
-                    "value": 45,
-                    "difference": 45
-                  },
-                  "vulnerabilities_count": {
-                    "value": 1997,
-                    "difference": 1997
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": "4",
+                      "asset_groups_score": {
+                        "value": 530,
+                        "difference": 530
+                      },
+                      "assets_count": {
+                        "value": 45,
+                        "difference": 45
+                      },
+                      "vulnerabilities_count": {
+                        "value": 1997,
+                        "difference": 1997
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14353,7 +14752,9 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14404,29 +14805,33 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "stacks": [
-                    {
-                      "name": "Test stack",
-                      "id": 1,
-                      "application_count_in_stack": 2,
-                      "risk_group_count_in_stack": 1,
-                      "application_score": 350,
-                      "risk_group_score": 640
-                    },
-                    {
-                      "name": "Other test stack",
-                      "id": 2,
-                      "application_count_in_stack": 2,
-                      "risk_group_count_in_stack": 1,
-                      "application_score": 0,
-                      "risk_group_score": 930
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "stacks": [
+                        {
+                          "name": "Test stack",
+                          "id": 1,
+                          "application_count_in_stack": 2,
+                          "risk_group_count_in_stack": 1,
+                          "application_score": 350,
+                          "risk_group_score": 640
+                        },
+                        {
+                          "name": "Other test stack",
+                          "id": 2,
+                          "application_count_in_stack": 2,
+                          "risk_group_count_in_stack": 1,
+                          "application_score": 0,
+                          "risk_group_score": 930
+                        }
+                      ],
+                      "meta": {
+                        "page": 1,
+                        "total_count": 3,
+                        "pages": 1
+                      }
                     }
-                  ],
-                  "meta": {
-                    "page": 1,
-                    "total_count": 3,
-                    "pages": 1
                   }
                 },
                 "schema": {
@@ -14470,16 +14875,20 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "stack": {
-                    "name": "Test stack",
-                    "id": 2,
-                    "application_ids": [
-                      284
-                    ],
-                    "asset_search_ids": [
-                      233
-                    ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "stack": {
+                        "name": "Test stack",
+                        "id": 2,
+                        "application_ids": [
+                          284
+                        ],
+                        "asset_search_ids": [
+                          233
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14608,25 +15017,29 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "user": {
-                    "id": 2,
-                    "created_at": "2009-04-23T12:20:06Z",
-                    "updated_at": "2016-02-26T17:41:28Z",
-                    "last_sign_in_at": "2016-03-26T17:41:28Z",
-                    "email": "demo+1@kennasecurity.com",
-                    "external_id": "geology",
-                    "firstname": "Demo",
-                    "lastname": "John",
-                    "phone": "888.316.3933",
-                    "roles": [
-                      "custom_role_1",
-                      "custom_role_2"
-                    ],
-                    "role_ids": [
-                      404,
-                      405
-                    ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "user": {
+                        "id": 2,
+                        "created_at": "2009-04-23T12:20:06Z",
+                        "updated_at": "2016-02-26T17:41:28Z",
+                        "last_sign_in_at": "2016-03-26T17:41:28Z",
+                        "email": "demo+1@kennasecurity.com",
+                        "external_id": "geology",
+                        "firstname": "Demo",
+                        "lastname": "John",
+                        "phone": "888.316.3933",
+                        "roles": [
+                          "custom_role_1",
+                          "custom_role_2"
+                        ],
+                        "role_ids": [
+                          404,
+                          405
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14669,26 +15082,30 @@
             "description": "201",
             "content": {
               "application/json": {
-                "example": {
-                  "user": {
-                    "id": 2,
-                    "created_at": "2016-02-26T17:41:28Z",
-                    "updated_at": "2016-02-26T17:41:28Z",
-                    "last_sign_in_at": "2016-03-26T17:41:28Z",
-                    "email": "demo@test.com",
-                    "external_id": "geology",
-                    "firstname": "Demo",
-                    "lastname": "John",
-                    "phone": "888.316.3933",
-                    "role": "normal user",
-                    "roles": [
-                      "normal user",
-                      "custom_user"
-                    ],
-                    "role_ids": [
-                      4422,
-                      4433
-                    ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "user": {
+                        "id": 2,
+                        "created_at": "2016-02-26T17:41:28Z",
+                        "updated_at": "2016-02-26T17:41:28Z",
+                        "last_sign_in_at": "2016-03-26T17:41:28Z",
+                        "email": "demo@test.com",
+                        "external_id": "geology",
+                        "firstname": "Demo",
+                        "lastname": "John",
+                        "phone": "888.316.3933",
+                        "role": "normal user",
+                        "roles": [
+                          "normal user",
+                          "custom_user"
+                        ],
+                        "role_ids": [
+                          4422,
+                          4433
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -14738,44 +15155,48 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "users": [
-                    {
-                      "id": 2,
-                      "created_at": "2009-04-23T12:20:06Z",
-                      "updated_at": "2016-02-26T17:41:28Z",
-                      "last_sign_in_at": "2016-03-26T17:41:28Z",
-                      "email": "demo+1@kennasecurity.com",
-                      "external_id": "geology",
-                      "firstname": "Demo",
-                      "lastname": "John",
-                      "phone": "888.316.3933",
-                      "roles": [
-                        "custom_role_1",
-                        "custom_role_2"
-                      ],
-                      "role_ids": [
-                        404,
-                        405
-                      ]
-                    },
-                    {
-                      "id": 44,
-                      "created_at": "2010-05-13T14:36:02Z",
-                      "updated_at": "2016-02-18T15:58:49Z",
-                      "email": "testuser2@honeyapps.com",
-                      "external_id": "chemistry",
-                      "firstname": "Jane",
-                      "lastname": "Doze",
-                      "phone": "800-555-1212",
-                      "roles": [
-                        "Linux Test Environment"
-                      ],
-                      "role_ids": [
-                        8244
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "users": [
+                        {
+                          "id": 2,
+                          "created_at": "2009-04-23T12:20:06Z",
+                          "updated_at": "2016-02-26T17:41:28Z",
+                          "last_sign_in_at": "2016-03-26T17:41:28Z",
+                          "email": "demo+1@kennasecurity.com",
+                          "external_id": "geology",
+                          "firstname": "Demo",
+                          "lastname": "John",
+                          "phone": "888.316.3933",
+                          "roles": [
+                            "custom_role_1",
+                            "custom_role_2"
+                          ],
+                          "role_ids": [
+                            404,
+                            405
+                          ]
+                        },
+                        {
+                          "id": 44,
+                          "created_at": "2010-05-13T14:36:02Z",
+                          "updated_at": "2016-02-18T15:58:49Z",
+                          "email": "testuser2@honeyapps.com",
+                          "external_id": "chemistry",
+                          "firstname": "Jane",
+                          "lastname": "Doze",
+                          "phone": "800-555-1212",
+                          "roles": [
+                            "Linux Test Environment"
+                          ],
+                          "role_ids": [
+                            8244
+                          ]
+                        }
                       ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "type": "object",
@@ -14828,85 +15249,89 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerability": {
-                    "id": 709836,
-                    "status": "open",
-                    "closed_at": null,
-                    "created_at": "2021-02-23T13:38:57Z",
-                    "due_date": null,
-                    "notes": null,
-                    "port": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerability": {
+                        "id": 709836,
+                        "status": "open",
+                        "closed_at": null,
+                        "created_at": "2021-02-23T13:38:57Z",
+                        "due_date": null,
+                        "notes": null,
+                        "port": [
 
-                    ],
-                    "priority": 10,
-                    "identifiers": [
-                      "133531"
-                    ],
-                    "last_seen_time": "2021-02-04T21:47:50.000Z",
-                    "scanner_score": 4.0,
-                    "fix_id": 1841225,
-                    "scanner_vulnerabilities": [
-                      {
-                        "port": null,
-                        "external_unique_id": "133531",
-                        "open": true
-                      }
-                    ],
-                    "asset_id": 12312,
-                    "connectors": [
-                      {
-                        "id": 157604,
-                        "name": "Nessus API Importer",
-                        "connector_definition_name": "Nessus API Importer",
-                        "vendor": "Tenable"
-                      }
-                    ],
-                    "service_ticket": {
-                      "status": "Active",
-                      "ticket_type": "jira",
-                      "external_identifier": "JR-123",
-                      "system_id": "12abcd345e6789101112f1g21h3ijk14",
-                      "due_date": "2021-08-12T03:14:57Z",
-                      "due_date_override": "2021-08-12T03:14:57Z"
-                    },
-                    "urls": {
-                      "asset": "api.kennasecurity.com/assets/12312"
-                    },
-                    "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later",
-                    "patch": true,
-                    "patch_published_at": null,
-                    "cve_id": "CVE-2019-11043",
-                    "cve_description": "In PHP versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 in certain configurations of FPM setup it is possible to cause FPM module to write past allocated buffers into the space reserved for FCGI protocol data, thus opening the possibility of remote code execution.",
-                    "cve_published_at": "2019-10-28T15:15:00.000Z",
-                    "description": null,
-                    "wasc_id": null,
-                    "severity": 8,
-                    "threat": 10,
-                    "popular_target": false,
-                    "active_internet_breach": true,
-                    "easily_exploitable": true,
-                    "malware_exploitable": false,
-                    "remote_code_execution": true,
-                    "predicted_exploitable": false,
-                    "custom_fields": [
+                        ],
+                        "priority": 10,
+                        "identifiers": [
+                          "133531"
+                        ],
+                        "last_seen_time": "2021-02-04T21:47:50.000Z",
+                        "scanner_score": 4.0,
+                        "fix_id": 1841225,
+                        "scanner_vulnerabilities": [
+                          {
+                            "port": null,
+                            "external_unique_id": "133531",
+                            "open": true
+                          }
+                        ],
+                        "asset_id": 12312,
+                        "connectors": [
+                          {
+                            "id": 157604,
+                            "name": "Nessus API Importer",
+                            "connector_definition_name": "Nessus API Importer",
+                            "vendor": "Tenable"
+                          }
+                        ],
+                        "service_ticket": {
+                          "status": "Active",
+                          "ticket_type": "jira",
+                          "external_identifier": "JR-123",
+                          "system_id": "12abcd345e6789101112f1g21h3ijk14",
+                          "due_date": "2021-08-12T03:14:57Z",
+                          "due_date_override": "2021-08-12T03:14:57Z"
+                        },
+                        "urls": {
+                          "asset": "api.kennasecurity.com/assets/12312"
+                        },
+                        "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later",
+                        "patch": true,
+                        "patch_published_at": null,
+                        "cve_id": "CVE-2019-11043",
+                        "cve_description": "In PHP versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 in certain configurations of FPM setup it is possible to cause FPM module to write past allocated buffers into the space reserved for FCGI protocol data, thus opening the possibility of remote code execution.",
+                        "cve_published_at": "2019-10-28T15:15:00.000Z",
+                        "description": null,
+                        "wasc_id": null,
+                        "severity": 8,
+                        "threat": 10,
+                        "popular_target": false,
+                        "active_internet_breach": true,
+                        "easily_exploitable": true,
+                        "malware_exploitable": false,
+                        "remote_code_execution": true,
+                        "predicted_exploitable": false,
+                        "custom_fields": [
 
-                    ],
-                    "first_found_on": "2021-02-23T13:38:57Z",
-                    "top_priority": true,
-                    "risk_meter_score": 100,
-                    "closed": false,
-                    "cvss_v2": {
-                      "score": 7.5,
-                      "exploit_subscore": 10.0,
-                      "impact_subscore": 6.4,
-                      "temporal_score": 7.5
-                    },
-                    "cvss_v3": {
-                      "score": 7.5,
-                      "exploit_subscore": 3.9,
-                      "impact_subscore": 3.6,
-                      "temporal_score": 9.4
+                        ],
+                        "first_found_on": "2021-02-23T13:38:57Z",
+                        "top_priority": true,
+                        "risk_meter_score": 100,
+                        "closed": false,
+                        "cvss_v2": {
+                          "score": 7.5,
+                          "exploit_subscore": 10.0,
+                          "impact_subscore": 6.4,
+                          "temporal_score": 7.5
+                        },
+                        "cvss_v3": {
+                          "score": 7.5,
+                          "exploit_subscore": 3.9,
+                          "impact_subscore": 3.6,
+                          "temporal_score": 9.4
+                        }
+                      }
                     }
                   }
                 },
@@ -14925,7 +15350,9 @@
             "description": "401",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -14965,7 +15392,9 @@
             "description": "204",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 }
               }
             }
@@ -14974,10 +15403,14 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
-                  "error": "unprocessable_entity",
-                  "message": "No vulnerabilites found",
-                  "success": "false"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "error": "unprocessable_entity",
+                      "message": "No vulnerabilites found",
+                      "success": "false"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -15017,7 +15450,9 @@
             "description": "204",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 }
               }
             }
@@ -15026,7 +15461,9 @@
             "description": "422",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -15077,17 +15514,21 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "scanner_vulnerabilities": [
-                    {
-                      "details": "{\\n  \\\"resource\\\": {\\n    \\\"type\\\": \\\"executable\\\",\\n    \\\"path\\\": \\\"/usr/bin/bash\\\"\\n  }\\n}",
-                      "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later"
-                    },
-                    {
-                      "details": "...",
-                      "solution": "..."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "scanner_vulnerabilities": [
+                        {
+                          "details": "{\\n  \\\"resource\\\": {\\n    \\\"type\\\": \\\"executable\\\",\\n    \\\"path\\\": \\\"/usr/bin/bash\\\"\\n  }\\n}",
+                          "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later"
+                        },
+                        {
+                          "details": "...",
+                          "solution": "..."
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/scanner_vulnerabilities_get_response_schema"
@@ -15099,7 +15540,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -15133,8 +15576,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerabilities_deleted": 3
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerabilities_deleted": 3
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/vulnerabilities_bulk_delete_response_schema"
@@ -15146,7 +15593,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -15192,8 +15641,12 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerabilities_updated": 5
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerabilities_updated": 5
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/vulnerabilities_bulk_updated_put_response_schema"
@@ -15205,7 +15658,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -15830,167 +16285,171 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerabilities": [
-                    {
-                      "connectors": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerabilities": [
                         {
-                          "name": "Nessus XML",
-                          "id": 1,
-                          "connector_definition_name": "Nessus XML",
-                          "vendor": "Tenable"
-                        }
-                      ],
-                      "notes": null,
-                      "fix_id": 73492,
-                      "service_ticket": null,
-                      "created_at": "2020-03-04T01:30:36Z",
-                      "asset_id": 21741,
-                      "id": 9401144,
-                      "last_seen_time": "2020-02-23T14:46:46.000Z",
-                      "closed_at": null,
-                      "identifiers": [
-                        "58988"
-                      ],
-                      "due_date": null,
-                      "priority": null,
-                      "port": [
-                        443
-                      ],
-                      "scanner_vulnerabilities": [
-                        {
-                          "port": 443,
-                          "external_unique_id": "58988",
-                          "open": true
-                        }
-                      ],
-                      "scanner_score": 3.0,
-                      "status": "open",
-                      "urls": {
-                        "asset": "api.nyc3.us.kennasecurity.com/assets/21741"
-                      },
-                      "solution": "Upgrade to PHP version 5.3.12 / 5.4.2 or later.  A 'mod_rewrite'\nworkaround is available as well.",
-                      "patch": true,
-                      "patch_published_at": null,
-                      "cve_id": "CVE-2012-1823",
-                      "cve_description": "sapi/cgi/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.",
-                      "cve_published_at": "2012-05-11T10:15:00.000Z",
-                      "description": null,
-                      "wasc_id": null,
-                      "severity": 8,
-                      "threat": 10,
-                      "popular_target": false,
-                      "active_internet_breach": true,
-                      "easily_exploitable": true,
-                      "malware_exploitable": false,
-                      "remote_code_execution": true,
-                      "predicted_exploitable": false,
-                      "custom_fields": [
+                          "connectors": [
+                            {
+                              "name": "Nessus XML",
+                              "id": 1,
+                              "connector_definition_name": "Nessus XML",
+                              "vendor": "Tenable"
+                            }
+                          ],
+                          "notes": null,
+                          "fix_id": 73492,
+                          "service_ticket": null,
+                          "created_at": "2020-03-04T01:30:36Z",
+                          "asset_id": 21741,
+                          "id": 9401144,
+                          "last_seen_time": "2020-02-23T14:46:46.000Z",
+                          "closed_at": null,
+                          "identifiers": [
+                            "58988"
+                          ],
+                          "due_date": null,
+                          "priority": null,
+                          "port": [
+                            443
+                          ],
+                          "scanner_vulnerabilities": [
+                            {
+                              "port": 443,
+                              "external_unique_id": "58988",
+                              "open": true
+                            }
+                          ],
+                          "scanner_score": 3.0,
+                          "status": "open",
+                          "urls": {
+                            "asset": "api.nyc3.us.kennasecurity.com/assets/21741"
+                          },
+                          "solution": "Upgrade to PHP version 5.3.12 / 5.4.2 or later.  A 'mod_rewrite'\nworkaround is available as well.",
+                          "patch": true,
+                          "patch_published_at": null,
+                          "cve_id": "CVE-2012-1823",
+                          "cve_description": "sapi/cgi/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.",
+                          "cve_published_at": "2012-05-11T10:15:00.000Z",
+                          "description": null,
+                          "wasc_id": null,
+                          "severity": 8,
+                          "threat": 10,
+                          "popular_target": false,
+                          "active_internet_breach": true,
+                          "easily_exploitable": true,
+                          "malware_exploitable": false,
+                          "remote_code_execution": true,
+                          "predicted_exploitable": false,
+                          "custom_fields": [
 
-                      ],
-                      "first_found_on": "2020-03-04T01:30:36Z",
-                      "risk_meter_score": 100,
-                      "top_priority": false,
-                      "closed": false,
-                      "cvss_v2": {
-                        "score": 7.5,
-                        "exploit_subscore": 10.0,
-                        "impact_subscore": 6.4,
-                        "temporal_score": 7.5
-                      },
-                      "cvss_v3": {
-                        "score": 7.5,
-                        "exploit_subscore": 3.9,
-                        "impact_subscore": 3.6,
-                        "temporal_score": 9.4
-                      }
-                    },
-                    {
-                      "connectors": [
-                        {
-                          "name": "Nessus XML",
-                          "id": 1,
-                          "connector_definition_name": "Nessus XML",
-                          "vendor": "Tenable"
-                        }
-                      ],
-                      "notes": null,
-                      "fix_id": 46299,
-                      "service_ticket": {
-                        "status": "Active",
-                        "ticket_type": "jira",
-                        "external_identifier": "JR-248",
-                        "system_id": "12abcd345e6789101112f1g21h3ijk14",
-                        "due_date": "2021-08-12T03:14:57Z",
-                        "due_date_override": "2022-07-11T03:15:57Z"
-                      },
-                      "created_at": "2020-03-06T21:47:15Z",
-                      "asset_id": 47906,
-                      "id": 31770054,
-                      "last_seen_time": "2020-02-24T09:26:54.000Z",
-                      "closed_at": null,
-                      "identifiers": [
-                        "78479"
-                      ],
-                      "due_date": null,
-                      "priority": null,
-                      "port": [
-                        443,
-                        5003
-                      ],
-                      "scanner_vulnerabilities": [
-                        {
-                          "port": 443,
-                          "external_unique_id": "78479",
-                          "open": true
+                          ],
+                          "first_found_on": "2020-03-04T01:30:36Z",
+                          "risk_meter_score": 100,
+                          "top_priority": false,
+                          "closed": false,
+                          "cvss_v2": {
+                            "score": 7.5,
+                            "exploit_subscore": 10.0,
+                            "impact_subscore": 6.4,
+                            "temporal_score": 7.5
+                          },
+                          "cvss_v3": {
+                            "score": 7.5,
+                            "exploit_subscore": 3.9,
+                            "impact_subscore": 3.6,
+                            "temporal_score": 9.4
+                          }
                         },
                         {
-                          "port": 5003,
-                          "external_unique_id": "78479",
-                          "open": true
+                          "connectors": [
+                            {
+                              "name": "Nessus XML",
+                              "id": 1,
+                              "connector_definition_name": "Nessus XML",
+                              "vendor": "Tenable"
+                            }
+                          ],
+                          "notes": null,
+                          "fix_id": 46299,
+                          "service_ticket": {
+                            "status": "Active",
+                            "ticket_type": "jira",
+                            "external_identifier": "JR-248",
+                            "system_id": "12abcd345e6789101112f1g21h3ijk14",
+                            "due_date": "2021-08-12T03:14:57Z",
+                            "due_date_override": "2022-07-11T03:15:57Z"
+                          },
+                          "created_at": "2020-03-06T21:47:15Z",
+                          "asset_id": 47906,
+                          "id": 31770054,
+                          "last_seen_time": "2020-02-24T09:26:54.000Z",
+                          "closed_at": null,
+                          "identifiers": [
+                            "78479"
+                          ],
+                          "due_date": null,
+                          "priority": null,
+                          "port": [
+                            443,
+                            5003
+                          ],
+                          "scanner_vulnerabilities": [
+                            {
+                              "port": 443,
+                              "external_unique_id": "78479",
+                              "open": true
+                            },
+                            {
+                              "port": 5003,
+                              "external_unique_id": "78479",
+                              "open": true
+                            }
+                          ],
+                          "scanner_score": 2.0,
+                          "status": "open",
+                          "urls": {
+                            "asset": "api.nyc3.us.kennasecurity.com/assets/47906"
+                          },
+                          "solution": "Disable SSLv3.\n\nServices that must support SSLv3 should enable the TLS Fallback SCSV mechanism until SSLv3 can be disabled.",
+                          "patch": true,
+                          "patch_published_at": null,
+                          "cve_id": "CVE-2014-3566",
+                          "cve_description": "The SSL protocol 3.0, as used in OpenSSL through 1.0.1i and other products, uses nondeterministic CBC padding, which makes it easier for man-in-the-middle attackers to obtain cleartext data via a padding-oracle attack, aka the \"POODLE\" issue.",
+                          "cve_published_at": "2014-10-15T00:55:00.000Z",
+                          "description": null,
+                          "wasc_id": null,
+                          "severity": 4,
+                          "threat": 9,
+                          "popular_target": true,
+                          "active_internet_breach": false,
+                          "easily_exploitable": true,
+                          "malware_exploitable": false,
+                          "remote_code_execution": false,
+                          "predicted_exploitable": false,
+                          "custom_fields": [
+
+                          ],
+                          "first_found_on": "2020-03-06T21:47:15Z",
+                          "risk_meter_score": 61,
+                          "top_priority": false,
+                          "closed": false,
+                          "cvss_v2": null,
+                          "cvss_v3": {
+                            "score": 7.8,
+                            "exploit_subscore": 3.5,
+                            "impact_subscore": 3.9,
+                            "temporal_score": 9.7
+                          }
                         }
                       ],
-                      "scanner_score": 2.0,
-                      "status": "open",
-                      "urls": {
-                        "asset": "api.nyc3.us.kennasecurity.com/assets/47906"
-                      },
-                      "solution": "Disable SSLv3.\n\nServices that must support SSLv3 should enable the TLS Fallback SCSV mechanism until SSLv3 can be disabled.",
-                      "patch": true,
-                      "patch_published_at": null,
-                      "cve_id": "CVE-2014-3566",
-                      "cve_description": "The SSL protocol 3.0, as used in OpenSSL through 1.0.1i and other products, uses nondeterministic CBC padding, which makes it easier for man-in-the-middle attackers to obtain cleartext data via a padding-oracle attack, aka the \"POODLE\" issue.",
-                      "cve_published_at": "2014-10-15T00:55:00.000Z",
-                      "description": null,
-                      "wasc_id": null,
-                      "severity": 4,
-                      "threat": 9,
-                      "popular_target": true,
-                      "active_internet_breach": false,
-                      "easily_exploitable": true,
-                      "malware_exploitable": false,
-                      "remote_code_execution": false,
-                      "predicted_exploitable": false,
-                      "custom_fields": [
-
-                      ],
-                      "first_found_on": "2020-03-06T21:47:15Z",
-                      "risk_meter_score": 61,
-                      "top_priority": false,
-                      "closed": false,
-                      "cvss_v2": null,
-                      "cvss_v3": {
-                        "score": 7.8,
-                        "exploit_subscore": 3.5,
-                        "impact_subscore": 3.9,
-                        "temporal_score": 9.7
+                      "meta": {
+                        "total_count": 2,
+                        "page": 1,
+                        "pages": 1
                       }
                     }
-                  ],
-                  "meta": {
-                    "total_count": 2,
-                    "page": 1,
-                    "pages": 1
                   }
                 },
                 "schema": {
@@ -16014,7 +16473,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16090,74 +16551,78 @@
             "description": "201",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerability": {
-                    "id": 100,
-                    "created_at": "2013-09-24T15:50:21Z",
-                    "last_seen_time": "2013-10-20T15:15:21Z",
-                    "closed": true,
-                    "closed_at": "2013-10-24T21:29:05Z",
-                    "status": "closed",
-                    "due_date": "2015-10-10T15:30:00Z",
-                    "risk_meter_score": 60,
-                    "priority": 0,
-                    "threat": 10,
-                    "severity": 5,
-                    "urls": {
-                      "asset": "https://api.kennasecurity.com/asset/98"
-                    },
-                    "notes": null,
-                    "patch": true,
-                    "patch_published_at": "2013-10-24T15:50:21Z",
-                    "port": 443,
-                    "active_internet_breach": false,
-                    "top_priority": false,
-                    "easily_exploitable": false,
-                    "predicted_exploitable": false,
-                    "malware_exploitable": false,
-                    "wasc_id": null,
-                    "cve_id": "CVE-2002-0510",
-                    "cve_published_at": "2013-10-15T15:50:21Z",
-                    "description": null,
-                    "cve_description": "This is a CVE",
-                    "solution": null,
-                    "asset_id": 98,
-                    "identifiers": [
-                      123
-                    ],
-                    "connectors": [
-                      {
-                        "id": 111,
-                        "name": "QualysGuard",
-                        "connector_definition_name": "QualysGuard",
-                        "vendor": "Qualys"
-                      },
-                      {
-                        "id": 222,
-                        "name": "QualysGuard",
-                        "connector_definition_name": "QualysGuard",
-                        "vendor": "Qualys"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerability": {
+                        "id": 100,
+                        "created_at": "2013-09-24T15:50:21Z",
+                        "last_seen_time": "2013-10-20T15:15:21Z",
+                        "closed": true,
+                        "closed_at": "2013-10-24T21:29:05Z",
+                        "status": "closed",
+                        "due_date": "2015-10-10T15:30:00Z",
+                        "risk_meter_score": 60,
+                        "priority": 0,
+                        "threat": 10,
+                        "severity": 5,
+                        "urls": {
+                          "asset": "https://api.kennasecurity.com/asset/98"
+                        },
+                        "notes": null,
+                        "patch": true,
+                        "patch_published_at": "2013-10-24T15:50:21Z",
+                        "port": 443,
+                        "active_internet_breach": false,
+                        "top_priority": false,
+                        "easily_exploitable": false,
+                        "predicted_exploitable": false,
+                        "malware_exploitable": false,
+                        "wasc_id": null,
+                        "cve_id": "CVE-2002-0510",
+                        "cve_published_at": "2013-10-15T15:50:21Z",
+                        "description": null,
+                        "cve_description": "This is a CVE",
+                        "solution": null,
+                        "asset_id": 98,
+                        "identifiers": [
+                          123
+                        ],
+                        "connectors": [
+                          {
+                            "id": 111,
+                            "name": "QualysGuard",
+                            "connector_definition_name": "QualysGuard",
+                            "vendor": "Qualys"
+                          },
+                          {
+                            "id": 222,
+                            "name": "QualysGuard",
+                            "connector_definition_name": "QualysGuard",
+                            "vendor": "Qualys"
+                          }
+                        ],
+                        "service_ticket": {
+                          "status": "Active",
+                          "ticket_type": "jira",
+                          "external_identifier": "JR-468",
+                          "system_id": "12abcd345e6789101112f1g21h3ijk14",
+                          "due_date": "2021-08-12T03:14:57Z",
+                          "due_date_override": "2022-08-12T03:14:57Z"
+                        },
+                        "cvss_v2": {
+                          "score": 7.5,
+                          "exploit_subscore": 10.0,
+                          "impact_subscore": 6.4,
+                          "temporal_score": 7.5
+                        },
+                        "cvss_v3": {
+                          "score": 7.5,
+                          "exploit_subscore": 3.9,
+                          "impact_subscore": 3.6,
+                          "temporal_score": 9.4
+                        }
                       }
-                    ],
-                    "service_ticket": {
-                      "status": "Active",
-                      "ticket_type": "jira",
-                      "external_identifier": "JR-468",
-                      "system_id": "12abcd345e6789101112f1g21h3ijk14",
-                      "due_date": "2021-08-12T03:14:57Z",
-                      "due_date_override": "2022-08-12T03:14:57Z"
-                    },
-                    "cvss_v2": {
-                      "score": 7.5,
-                      "exploit_subscore": 10.0,
-                      "impact_subscore": 6.4,
-                      "temporal_score": 7.5
-                    },
-                    "cvss_v3": {
-                      "score": 7.5,
-                      "exploit_subscore": 3.9,
-                      "impact_subscore": 3.6,
-                      "temporal_score": 9.4
                     }
                   }
                 },
@@ -16176,7 +16641,9 @@
             "description": "401",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16238,167 +16705,171 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerabilities": [
-                    {
-                      "id": 709836,
-                      "status": "open",
-                      "closed_at": null,
-                      "created_at": "2021-02-23T13:38:57Z",
-                      "due_date": null,
-                      "notes": null,
-                      "port": [
-
-                      ],
-                      "priority": 10,
-                      "identifiers": [
-                        "133531"
-                      ],
-                      "last_seen_time": "2021-02-04T21:47:50.000Z",
-                      "scanner_score": 4.0,
-                      "fix_id": 1841225,
-                      "scanner_vulnerabilities": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerabilities": [
                         {
-                          "port": null,
-                          "external_unique_id": "133531",
-                          "open": true
+                          "id": 709836,
+                          "status": "open",
+                          "closed_at": null,
+                          "created_at": "2021-02-23T13:38:57Z",
+                          "due_date": null,
+                          "notes": null,
+                          "port": [
+
+                          ],
+                          "priority": 10,
+                          "identifiers": [
+                            "133531"
+                          ],
+                          "last_seen_time": "2021-02-04T21:47:50.000Z",
+                          "scanner_score": 4.0,
+                          "fix_id": 1841225,
+                          "scanner_vulnerabilities": [
+                            {
+                              "port": null,
+                              "external_unique_id": "133531",
+                              "open": true
+                            }
+                          ],
+                          "asset_id": 12312,
+                          "connectors": [
+                            {
+                              "id": 157604,
+                              "name": "Nessus API Importer",
+                              "connector_definition_name": "Nessus API Importer",
+                              "vendor": "Tenable"
+                            }
+                          ],
+                          "service_ticket": {
+                            "status": "Active",
+                            "ticket_type": "jira",
+                            "external_identifier": "JR-123",
+                            "system_id": "12abcd345e6789101112f1g21h3ijk14",
+                            "due_date": "2021-08-12T03:14:57Z",
+                            "due_date_override": "2021-08-12T03:14:57Z"
+                          },
+                          "urls": {
+                            "asset": "api.kennasecurity.com/assets/12312"
+                          },
+                          "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later",
+                          "patch": true,
+                          "patch_published_at": null,
+                          "cve_id": "CVE-2019-11043",
+                          "cve_description": "In PHP versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 in certain configurations of FPM setup it is possible to cause FPM module to write past allocated buffers into the space reserved for FCGI protocol data, thus opening the possibility of remote code execution.",
+                          "cve_published_at": "2019-10-28T15:15:00.000Z",
+                          "description": null,
+                          "wasc_id": null,
+                          "severity": 8,
+                          "threat": 10,
+                          "popular_target": false,
+                          "active_internet_breach": true,
+                          "easily_exploitable": true,
+                          "malware_exploitable": false,
+                          "remote_code_execution": true,
+                          "predicted_exploitable": false,
+                          "custom_fields": [
+
+                          ],
+                          "first_found_on": "2021-02-23T13:38:57Z",
+                          "top_priority": true,
+                          "risk_meter_score": 100,
+                          "closed": false,
+                          "cvss_v2": {
+                            "score": 7.5,
+                            "exploit_subscore": 10.0,
+                            "impact_subscore": 6.4,
+                            "temporal_score": 7.5
+                          },
+                          "cvss_v3": {
+                            "score": 7.5,
+                            "exploit_subscore": 3.9,
+                            "impact_subscore": 3.6,
+                            "temporal_score": 9.4
+                          }
+                        },
+                        {
+                          "id": 708136,
+                          "status": "open",
+                          "closed_at": null,
+                          "created_at": "2021-02-23T13:38:49Z",
+                          "due_date": null,
+                          "notes": null,
+                          "port": [
+                            445
+                          ],
+                          "priority": 10,
+                          "identifiers": [
+                            "122118"
+                          ],
+                          "last_seen_time": "2021-02-18T21:33:12.000Z",
+                          "scanner_score": 3.0,
+                          "fix_id": 1841079,
+                          "scanner_vulnerabilities": [
+                            {
+                              "port": 445,
+                              "external_unique_id": "122118",
+                              "open": true
+                            }
+                          ],
+                          "asset_id": 12309,
+                          "connectors": [
+                            {
+                              "id": 157604,
+                              "name": "Nessus API Importer",
+                              "connector_definition_name": "Nessus API Importer",
+                              "vendor": "Tenable"
+                            }
+                          ],
+                          "service_ticket": {
+                            "status": "Active",
+                            "ticket_type": "jira",
+                            "external_identifier": "JR-123",
+                            "system_id": "12abcd345e6789101112f1g21h3ijk14",
+                            "due_date": "2021-08-12T03:14:57Z",
+                            "due_date_override": "2021-08-12T03:14:57Z"
+                          },
+                          "urls": {
+                            "asset": "api.kennasecurity.com/assets/12309"
+                          },
+                          "solution": "Apply Security Only update KB4486564 or Cumulative Update KB4486563.",
+                          "patch": true,
+                          "patch_published_at": null,
+                          "cve_id": "CVE-2019-0595",
+                          "cve_description": "A remote code execution vulnerability exists when the Windows Jet Database Engine improperly handles objects in memory, aka 'Jet Database Engine Remote Code Execution Vulnerability'. This CVE ID is unique from CVE-2019-0596, CVE-2019-0597, CVE-2019-0598, CVE-2019-0599, CVE-2019-0625.",
+                          "cve_published_at": "2019-03-05T23:29:00.000Z",
+                          "description": null,
+                          "wasc_id": null,
+                          "severity": 9,
+                          "threat": 9,
+                          "popular_target": true,
+                          "active_internet_breach": false,
+                          "easily_exploitable": false,
+                          "malware_exploitable": false,
+                          "remote_code_execution": true,
+                          "predicted_exploitable": true,
+                          "custom_fields": [
+
+                          ],
+                          "first_found_on": "2021-02-23T13:38:49Z",
+                          "top_priority": true,
+                          "risk_meter_score": 46,
+                          "closed": false,
+                          "cvss_v2": {
+                            "score": 5.5,
+                            "exploit_subscore": 10.0,
+                            "impact_subscore": 6.5,
+                            "temporal_score": 7.4
+                          },
+                          "cvss_v3": null
                         }
                       ],
-                      "asset_id": 12312,
-                      "connectors": [
-                        {
-                          "id": 157604,
-                          "name": "Nessus API Importer",
-                          "connector_definition_name": "Nessus API Importer",
-                          "vendor": "Tenable"
-                        }
-                      ],
-                      "service_ticket": {
-                        "status": "Active",
-                        "ticket_type": "jira",
-                        "external_identifier": "JR-123",
-                        "system_id": "12abcd345e6789101112f1g21h3ijk14",
-                        "due_date": "2021-08-12T03:14:57Z",
-                        "due_date_override": "2021-08-12T03:14:57Z"
-                      },
-                      "urls": {
-                        "asset": "api.kennasecurity.com/assets/12312"
-                      },
-                      "solution": "Upgrade to macOS 10.13.6, 10.14.6, 10.15.3 or later",
-                      "patch": true,
-                      "patch_published_at": null,
-                      "cve_id": "CVE-2019-11043",
-                      "cve_description": "In PHP versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 in certain configurations of FPM setup it is possible to cause FPM module to write past allocated buffers into the space reserved for FCGI protocol data, thus opening the possibility of remote code execution.",
-                      "cve_published_at": "2019-10-28T15:15:00.000Z",
-                      "description": null,
-                      "wasc_id": null,
-                      "severity": 8,
-                      "threat": 10,
-                      "popular_target": false,
-                      "active_internet_breach": true,
-                      "easily_exploitable": true,
-                      "malware_exploitable": false,
-                      "remote_code_execution": true,
-                      "predicted_exploitable": false,
-                      "custom_fields": [
-
-                      ],
-                      "first_found_on": "2021-02-23T13:38:57Z",
-                      "top_priority": true,
-                      "risk_meter_score": 100,
-                      "closed": false,
-                      "cvss_v2": {
-                        "score": 7.5,
-                        "exploit_subscore": 10.0,
-                        "impact_subscore": 6.4,
-                        "temporal_score": 7.5
-                      },
-                      "cvss_v3": {
-                        "score": 7.5,
-                        "exploit_subscore": 3.9,
-                        "impact_subscore": 3.6,
-                        "temporal_score": 9.4
+                      "meta": {
+                        "page": 1,
+                        "pages": 18
                       }
-                    },
-                    {
-                      "id": 708136,
-                      "status": "open",
-                      "closed_at": null,
-                      "created_at": "2021-02-23T13:38:49Z",
-                      "due_date": null,
-                      "notes": null,
-                      "port": [
-                        445
-                      ],
-                      "priority": 10,
-                      "identifiers": [
-                        "122118"
-                      ],
-                      "last_seen_time": "2021-02-18T21:33:12.000Z",
-                      "scanner_score": 3.0,
-                      "fix_id": 1841079,
-                      "scanner_vulnerabilities": [
-                        {
-                          "port": 445,
-                          "external_unique_id": "122118",
-                          "open": true
-                        }
-                      ],
-                      "asset_id": 12309,
-                      "connectors": [
-                        {
-                          "id": 157604,
-                          "name": "Nessus API Importer",
-                          "connector_definition_name": "Nessus API Importer",
-                          "vendor": "Tenable"
-                        }
-                      ],
-                      "service_ticket": {
-                        "status": "Active",
-                        "ticket_type": "jira",
-                        "external_identifier": "JR-123",
-                        "system_id": "12abcd345e6789101112f1g21h3ijk14",
-                        "due_date": "2021-08-12T03:14:57Z",
-                        "due_date_override": "2021-08-12T03:14:57Z"
-                      },
-                      "urls": {
-                        "asset": "api.kennasecurity.com/assets/12309"
-                      },
-                      "solution": "Apply Security Only update KB4486564 or Cumulative Update KB4486563.",
-                      "patch": true,
-                      "patch_published_at": null,
-                      "cve_id": "CVE-2019-0595",
-                      "cve_description": "A remote code execution vulnerability exists when the Windows Jet Database Engine improperly handles objects in memory, aka 'Jet Database Engine Remote Code Execution Vulnerability'. This CVE ID is unique from CVE-2019-0596, CVE-2019-0597, CVE-2019-0598, CVE-2019-0599, CVE-2019-0625.",
-                      "cve_published_at": "2019-03-05T23:29:00.000Z",
-                      "description": null,
-                      "wasc_id": null,
-                      "severity": 9,
-                      "threat": 9,
-                      "popular_target": true,
-                      "active_internet_breach": false,
-                      "easily_exploitable": false,
-                      "malware_exploitable": false,
-                      "remote_code_execution": true,
-                      "predicted_exploitable": true,
-                      "custom_fields": [
-
-                      ],
-                      "first_found_on": "2021-02-23T13:38:49Z",
-                      "top_priority": true,
-                      "risk_meter_score": 46,
-                      "closed": false,
-                      "cvss_v2": {
-                        "score": 5.5,
-                        "exploit_subscore": 10.0,
-                        "impact_subscore": 6.5,
-                        "temporal_score": 7.4
-                      },
-                      "cvss_v3": null
                     }
-                  ],
-                  "meta": {
-                    "page": 1,
-                    "pages": 18
                   }
                 },
                 "schema": {
@@ -16422,7 +16893,9 @@
             "description": "400",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16472,104 +16945,108 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "vulnerability_definition": {
-                    "exploits": [
-                      {
-                        "created_at": "2021-04-21T08:00:16Z",
-                        "external_id": null,
-                        "name": "Script-JS.Exploit.CVE-2021-21206",
-                        "source": "reversing_labs",
-                        "url": null
-                      }
-                    ],
-                    "fixes": [
-                      {
-                        "external_id": "375445",
-                        "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
-                        "product": "chrome",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "google-chrome-cve-2021-21206",
-                        "url": null,
-                        "product": null,
-                        "published_at": "2021-04-14T00:00:00Z"
-                      },
-                      {
-                        "external_id": "375446",
-                        "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
-                        "product": "edge_chromium",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "710018",
-                        "url": "https://security.gentoo.org/glsa/202104-08",
-                        "product": "None",
-                        "published_at": "2021-05-05T14:04:31Z"
-                      }
-                    ],
-                    "threat_actors": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "vulnerability_definition": {
+                        "exploits": [
+                          {
+                            "created_at": "2021-04-21T08:00:16Z",
+                            "external_id": null,
+                            "name": "Script-JS.Exploit.CVE-2021-21206",
+                            "source": "reversing_labs",
+                            "url": null
+                          }
+                        ],
+                        "fixes": [
+                          {
+                            "external_id": "375445",
+                            "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
+                            "product": "chrome",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "google-chrome-cve-2021-21206",
+                            "url": null,
+                            "product": null,
+                            "published_at": "2021-04-14T00:00:00Z"
+                          },
+                          {
+                            "external_id": "375446",
+                            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
+                            "product": "edge_chromium",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "710018",
+                            "url": "https://security.gentoo.org/glsa/202104-08",
+                            "product": "None",
+                            "published_at": "2021-05-05T14:04:31Z"
+                          }
+                        ],
+                        "threat_actors": [
 
-                    ],
-                    "created_at": "2020-12-22T00:00:07Z",
-                    "daily_trend": "down",
-                    "predicted_exploitable": false,
-                    "predicted_exploitable_confidence": 0.000720525,
-                    "successful_exploitations": 6657,
-                    "velocity_day": 12,
-                    "velocity_month": 6657,
-                    "velocity_week": 684,
-                    "cve_id": "CVE-2021-21206",
-                    "cvss_score": 6.8,
-                    "cvss_exploit_subscore": 8.6,
-                    "cvss_impact_subscore": 6.4,
-                    "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                    "cvss_temporal_score": 5.0,
-                    "cvss_v3_score": 8.8,
-                    "cvss_v3_exploit_subscore": 2.8,
-                    "cvss_v3_impact_subscore": 5.9,
-                    "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                    "cvss_v3_temporal_score": null,
-                    "last_modified": "2021-05-01T02:15:00Z",
-                    "published": "2021-04-26T17:15:00Z",
-                    "vulnerable_products": [
-                      "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
-                    ],
-                    "id": 2853560,
-                    "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "cvss_access_complexity": "Medium",
-                    "cvss_access_vector": "Network",
-                    "cvss_authentication": "None required",
-                    "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "risk_meter_score": 77.1296,
-                    "cvss_availability_impact": "Partial",
-                    "cvss_confidentiality_impact": "Partial",
-                    "cvss_integrity_impact": "Partial",
-                    "easily_exploitable": true,
-                    "malware_exploitable": true,
-                    "active_internet_breach": true,
-                    "malware_count": 1,
-                    "chatter_count": 2,
-                    "popular_target": true,
-                    "remote_code_execution": false,
-                    "pre_nvd_chatter": false,
-                    "state": "published",
-                    "stride_threat": [
-                      "denial of Service"
-                    ],
-                    "vulnerability_type": [
-                      "Heap-based Buffer Overflow",
-                      "Denial of Service",
-                      "DoS"
-                    ],
-                    "exploitation_methodology": [
-                      "configured with storm control profiling"
-                    ],
-                    "affected_source_file_module": [
-                      "packet forwarding engine",
-                      "PFE"
-                    ]
+                        ],
+                        "created_at": "2020-12-22T00:00:07Z",
+                        "daily_trend": "down",
+                        "predicted_exploitable": false,
+                        "predicted_exploitable_confidence": 0.000720525,
+                        "successful_exploitations": 6657,
+                        "velocity_day": 12,
+                        "velocity_month": 6657,
+                        "velocity_week": 684,
+                        "cve_id": "CVE-2021-21206",
+                        "cvss_score": 6.8,
+                        "cvss_exploit_subscore": 8.6,
+                        "cvss_impact_subscore": 6.4,
+                        "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                        "cvss_temporal_score": 5.0,
+                        "cvss_v3_score": 8.8,
+                        "cvss_v3_exploit_subscore": 2.8,
+                        "cvss_v3_impact_subscore": 5.9,
+                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                        "cvss_v3_temporal_score": null,
+                        "last_modified": "2021-05-01T02:15:00Z",
+                        "published": "2021-04-26T17:15:00Z",
+                        "vulnerable_products": [
+                          "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
+                        ],
+                        "id": 2853560,
+                        "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "cvss_access_complexity": "Medium",
+                        "cvss_access_vector": "Network",
+                        "cvss_authentication": "None required",
+                        "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "risk_meter_score": 77.1296,
+                        "cvss_availability_impact": "Partial",
+                        "cvss_confidentiality_impact": "Partial",
+                        "cvss_integrity_impact": "Partial",
+                        "easily_exploitable": true,
+                        "malware_exploitable": true,
+                        "active_internet_breach": true,
+                        "malware_count": 1,
+                        "chatter_count": 2,
+                        "popular_target": true,
+                        "remote_code_execution": false,
+                        "pre_nvd_chatter": false,
+                        "state": "published",
+                        "stride_threat": [
+                          "denial of Service"
+                        ],
+                        "vulnerability_type": [
+                          "Heap-based Buffer Overflow",
+                          "Denial of Service",
+                          "DoS"
+                        ],
+                        "exploitation_methodology": [
+                          "configured with storm control profiling"
+                        ],
+                        "affected_source_file_module": [
+                          "packet forwarding engine",
+                          "PFE"
+                        ]
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -16587,10 +17064,14 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "not_found",
-                  "message": "Vulnerability Definition not found."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "not_found",
+                      "message": "Vulnerability Definition not found."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16632,50 +17113,54 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "chatter": {
-                    "created_at": "2020-12-27T06:57:43.000Z",
-                    "id": 12984,
-                    "sightings": [
-                      {
-                        "source": "Threat Post",
-                        "url": "https://threatpost.com/adobe-unscheduled-update-fixes-critical-coldfusion-flaws/148616/"
-                      },
-                      {
-                        "fragment": "The important flaw (CVE-2019-8072) meanwhile is a security bypass that could allow information disclosure, discovered by Pete Freitag with Foundeo Inc.",
-                        "published": 1569355081000
-                      },
-                      {
-                        "title": "Adobe Unscheduled Update Fixes Critical ColdFusion Flaws",
-                        "type": "first"
-                      },
-                      {
-                        "source": "Sesin at",
-                        "url": "https://www.sesin.at/2020/09/12/adobe-coldfusion-2018-update-4-up-to-2016-update-11-information-disclosure/"
-                      },
-                      {
-                        "fragment": "CVE : CVE-2019-8072 ( ) See also :",
-                        "published": 1599886845000
-                      },
-                      {
-                        "title": "Adobe ColdFusion 2018 Update 4/up to 2016 Update 11 information disclosure",
-                        "type": "recentInfoSec"
-                      },
-                      {
-                        "source": "Adobe Security Bulletins and Advisories",
-                        "url": "https://Adobe%20Security%20Bulletins%20and%20Advisories%20(Obfuscated)/security/products/coldfusion/apsb19-47.html"
-                      },
-                      {
-                        "fragment": "* Pete Freitag / Foundeo Inc. (<https://foundeo.com/>) (CVE-2019-8072)",
-                        "published": 1575936000000
-                      },
-                      {
-                        "title": "APSB19-58 Security update available for Adobe ColdFusion",
-                        "type": "mostRecent"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "chatter": {
+                        "created_at": "2020-12-27T06:57:43.000Z",
+                        "id": 12984,
+                        "sightings": [
+                          {
+                            "source": "Threat Post",
+                            "url": "https://threatpost.com/adobe-unscheduled-update-fixes-critical-coldfusion-flaws/148616/"
+                          },
+                          {
+                            "fragment": "The important flaw (CVE-2019-8072) meanwhile is a security bypass that could allow information disclosure, discovered by Pete Freitag with Foundeo Inc.",
+                            "published": 1569355081000
+                          },
+                          {
+                            "title": "Adobe Unscheduled Update Fixes Critical ColdFusion Flaws",
+                            "type": "first"
+                          },
+                          {
+                            "source": "Sesin at",
+                            "url": "https://www.sesin.at/2020/09/12/adobe-coldfusion-2018-update-4-up-to-2016-update-11-information-disclosure/"
+                          },
+                          {
+                            "fragment": "CVE : CVE-2019-8072 ( ) See also :",
+                            "published": 1599886845000
+                          },
+                          {
+                            "title": "Adobe ColdFusion 2018 Update 4/up to 2016 Update 11 information disclosure",
+                            "type": "recentInfoSec"
+                          },
+                          {
+                            "source": "Adobe Security Bulletins and Advisories",
+                            "url": "https://Adobe%20Security%20Bulletins%20and%20Advisories%20(Obfuscated)/security/products/coldfusion/apsb19-47.html"
+                          },
+                          {
+                            "fragment": "* Pete Freitag / Foundeo Inc. (<https://foundeo.com/>) (CVE-2019-8072)",
+                            "published": 1575936000000
+                          },
+                          {
+                            "title": "APSB19-58 Security update available for Adobe ColdFusion",
+                            "type": "mostRecent"
+                          }
+                        ],
+                        "updated_at": "2020-12-27T07:05:33.000Z",
+                        "vulnerability_definition_id": 709379
                       }
-                    ],
-                    "updated_at": "2020-12-27T07:05:33.000Z",
-                    "vulnerability_definition_id": 709379
+                    }
                   }
                 },
                 "schema": {
@@ -16688,7 +17173,9 @@
             "description": "403",
             "content": {
               "application/json": {
-                "example": {
+                "examples": {
+                  "example_0": {
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16700,92 +17187,14 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "not_found",
-                  "message": "Vulnerability Definition not found."
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/error_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/vulnerability_definitions/{cve_id}/malware_families": {
-      "get": {
-        "summary": "Show Malware Family Data",
-        "description": "<p>Displays the known malware variant name and malware classifications (family) that are mentioned with a particular CVE.  Family type includes classifications such as Ransomware.  Returns malware family statistics for a single vulnerability definition by CVE ID.</p><div class=\"pin\"><blockquote class=\"callout callout_warn\" theme=\"🚧\"><h3 class=\"callout-heading false\"><span class=\"callout-icon\">🚧</span><p>Restricted Access</p></h3><p>This API endpoint is a premium feature and requires access to the Kenna.VI+ API.</p></blockquote></div>",
-        "operationId": "show-malware-family-data",
-        "security": [
-          {
-            "X-Risk-Token": [
-
-            ]
-          }
-        ],
-        "tags": [
-          "KENNA.VI+"
-        ],
-        "parameters": [
-          {
-            "name": "cve_id",
-            "in": "path",
-            "description": "A CVE in the form of CVE-YYYY-nnnnn.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "example": [
-                  {
-                    "malware_family": {
-                      "id": 24104,
-                      "name": "SMBRelay",
-                      "malware_family_type": "Trojan",
-                      "source": "kenna_intel",
-                      "ref_count": 2,
-                      "curated": true,
-                      "vulnerability_definition_id": 1068593,
-                      "created_at": "2020-08-07T22:15:49.000Z",
-                      "updated_at": "2020-08-13T20:35:02.000Z"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "not_found",
+                      "message": "Vulnerability Definition not found."
                     }
                   }
-                ],
-                "schema": {
-                  "$ref": "#/components/schemas/malware_family_get_response_schema"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "403",
-            "content": {
-              "application/json": {
-                "example": {
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/error_response"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "404",
-            "content": {
-              "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "not_found",
-                  "message": "Vulnerability Definition not found."
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16827,14 +17236,18 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "malware": [
-                    {
-                      "md5": "0fcb5037c8268c84acfdf15e1e8ea496",
-                      "sha1": "4f733c8f4f38ea864f84949e5a956fd3ddbb4ca0",
-                      "sha256": "cf7dc8c0c6dd0f9aaaa39229688aa9f00c8d1371563ff97cbaab04db9bde5210"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "malware": [
+                        {
+                          "md5": "0fcb5037c8268c84acfdf15e1e8ea496",
+                          "sha1": "4f733c8f4f38ea864f84949e5a956fd3ddbb4ca0",
+                          "sha256": "cf7dc8c0c6dd0f9aaaa39229688aa9f00c8d1371563ff97cbaab04db9bde5210"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/malware_hash_get_response_schema"
@@ -16846,10 +17259,14 @@
             "description": "404",
             "content": {
               "application/json": {
-                "example": {
-                  "success": "false",
-                  "error": "not_found",
-                  "message": "Vulnerability Definition not found."
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "success": "false",
+                      "error": "not_found",
+                      "message": "Vulnerability Definition not found."
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -16922,35 +17339,39 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "cve_identifiers": [
-                    "CVE-1999-0001",
-                    "CVE-1999-0002",
-                    "CVE-1999-0003",
-                    "CVE-1999-0004",
-                    "CVE-1999-0005",
-                    "CVE-1999-0006",
-                    "CVE-1999-0007",
-                    "CVE-1999-0008",
-                    "CVE-1999-0009",
-                    "CVE-1999-0010",
-                    "CVE-1999-0011",
-                    "CVE-1999-0012",
-                    "CVE-1999-0013",
-                    "CVE-1999-0014",
-                    "CVE-1999-0015",
-                    "CVE-1999-0016",
-                    "CVE-1999-0017",
-                    "CVE-1999-0018",
-                    "CVE-1999-0019",
-                    "CVE-1999-0020",
-                    "CVE-1999-0021",
-                    "CVE-1999-0022",
-                    "CVE-1999-0023",
-                    "CVE-1999-0024",
-                    "CVE-1999-0025",
-                    "CVE-1999-0026"
-                  ]
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "cve_identifiers": [
+                        "CVE-1999-0001",
+                        "CVE-1999-0002",
+                        "CVE-1999-0003",
+                        "CVE-1999-0004",
+                        "CVE-1999-0005",
+                        "CVE-1999-0006",
+                        "CVE-1999-0007",
+                        "CVE-1999-0008",
+                        "CVE-1999-0009",
+                        "CVE-1999-0010",
+                        "CVE-1999-0011",
+                        "CVE-1999-0012",
+                        "CVE-1999-0013",
+                        "CVE-1999-0014",
+                        "CVE-1999-0015",
+                        "CVE-1999-0016",
+                        "CVE-1999-0017",
+                        "CVE-1999-0018",
+                        "CVE-1999-0019",
+                        "CVE-1999-0020",
+                        "CVE-1999-0021",
+                        "CVE-1999-0022",
+                        "CVE-1999-0023",
+                        "CVE-1999-0024",
+                        "CVE-1999-0025",
+                        "CVE-1999-0026"
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/cve_identifiers_get_response_schema"
@@ -17001,96 +17422,100 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "CVE-2018-0866": {
-                    "id": 466688,
-                    "risk_meter_score": 82,
-                    "risk_meter_score_history": [
-                      {
-                        "changed_at": "2018-02-18T04:01:34.000Z",
-                        "from": 25,
-                        "to": 28
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "CVE-2018-0866": {
+                        "id": 466688,
+                        "risk_meter_score": 82,
+                        "risk_meter_score_history": [
+                          {
+                            "changed_at": "2018-02-18T04:01:34.000Z",
+                            "from": 25,
+                            "to": 28
+                          },
+                          {
+                            "changed_at": "2018-02-22T03:53:23.000Z",
+                            "from": 28,
+                            "to": 40
+                          },
+                          {
+                            "changed_at": "2018-03-14T04:37:36.000Z",
+                            "from": 40,
+                            "to": 58
+                          },
+                          {
+                            "changed_at": "2018-03-15T03:50:28.000Z",
+                            "from": 58,
+                            "to": 52
+                          },
+                          {
+                            "changed_at": "2018-05-10T03:52:44.000Z",
+                            "from": 52,
+                            "to": 85
+                          },
+                          {
+                            "changed_at": "2018-10-31T03:30:24.000Z",
+                            "from": 85,
+                            "to": 82
+                          }
+                        ]
                       },
-                      {
-                        "changed_at": "2018-02-22T03:53:23.000Z",
-                        "from": 28,
-                        "to": 40
+                      "CVE-2019-0708": {
+                        "id": 505973,
+                        "risk_meter_score": 100,
+                        "risk_meter_score_history": [
+                          {
+                            "changed_at": "2019-05-16T01:40:33.000Z",
+                            "from": 0,
+                            "to": 36
+                          },
+                          {
+                            "changed_at": "2019-05-16T16:39:27.000Z",
+                            "from": 36,
+                            "to": 54
+                          },
+                          {
+                            "changed_at": "2019-05-17T03:25:22.000Z",
+                            "from": 54,
+                            "to": 50
+                          },
+                          {
+                            "changed_at": "2019-05-19T03:58:17.000Z",
+                            "from": 50,
+                            "to": 47
+                          },
+                          {
+                            "changed_at": "2019-05-21T03:33:09.000Z",
+                            "from": 47,
+                            "to": 51
+                          },
+                          {
+                            "changed_at": "2019-05-23T03:32:49.000Z",
+                            "from": 51,
+                            "to": 58
+                          },
+                          {
+                            "changed_at": "2019-05-26T03:45:18.000Z",
+                            "from": 58,
+                            "to": 94
+                          },
+                          {
+                            "changed_at": "2019-07-31T03:29:30.000Z",
+                            "from": 94,
+                            "to": 100
+                          }
+                        ]
                       },
-                      {
-                        "changed_at": "2018-03-14T04:37:36.000Z",
-                        "from": 40,
-                        "to": 58
-                      },
-                      {
-                        "changed_at": "2018-03-15T03:50:28.000Z",
-                        "from": 58,
-                        "to": 52
-                      },
-                      {
-                        "changed_at": "2018-05-10T03:52:44.000Z",
-                        "from": 52,
-                        "to": 85
-                      },
-                      {
-                        "changed_at": "2018-10-31T03:30:24.000Z",
-                        "from": 85,
-                        "to": 82
+                      "warning": {
+                        "code": 1,
+                        "message": "Customers who have not purchased the Threat API may only access CVEs that correspond to vulnerabilities in their instance",
+                        "unavailable_cve_identifiers": [
+                          "CVE-2019-0709"
+                        ],
+                        "url": "https://apidocs.kennasecurity.com/reference#show-cve-history"
                       }
-                    ]
-                  },
-                  "CVE-2019-0708": {
-                    "id": 505973,
-                    "risk_meter_score": 100,
-                    "risk_meter_score_history": [
-                      {
-                        "changed_at": "2019-05-16T01:40:33.000Z",
-                        "from": 0,
-                        "to": 36
-                      },
-                      {
-                        "changed_at": "2019-05-16T16:39:27.000Z",
-                        "from": 36,
-                        "to": 54
-                      },
-                      {
-                        "changed_at": "2019-05-17T03:25:22.000Z",
-                        "from": 54,
-                        "to": 50
-                      },
-                      {
-                        "changed_at": "2019-05-19T03:58:17.000Z",
-                        "from": 50,
-                        "to": 47
-                      },
-                      {
-                        "changed_at": "2019-05-21T03:33:09.000Z",
-                        "from": 47,
-                        "to": 51
-                      },
-                      {
-                        "changed_at": "2019-05-23T03:32:49.000Z",
-                        "from": 51,
-                        "to": 58
-                      },
-                      {
-                        "changed_at": "2019-05-26T03:45:18.000Z",
-                        "from": 58,
-                        "to": 94
-                      },
-                      {
-                        "changed_at": "2019-07-31T03:29:30.000Z",
-                        "from": 94,
-                        "to": 100
-                      }
-                    ]
-                  },
-                  "warning": {
-                    "code": 1,
-                    "message": "Customers who have not purchased the Threat API may only access CVEs that correspond to vulnerabilities in their instance",
-                    "unavailable_cve_identifiers": [
-                      "CVE-2019-0709"
-                    ],
-                    "url": "https://apidocs.kennasecurity.com/reference#show-cve-history"
+                    }
                   }
                 },
                 "schema": {
@@ -17115,7 +17540,7 @@
     "/vulnerability_definitions/search": {
       "get": {
         "summary": "Search for Vulnerability Definitions",
-        "description": "<p>Returns vulnerability definitions that match the given search criteria.</p><div class=\"pin\"><blockquote class=\"callout callout_warn\" theme=\"🚧\"><h3 class=\"callout-heading false\"><span class=\"callout-icon\">🚧</span><p>Restricted Access</p></h3><p>This API endpoint is a premium feature and requires access to the Kenna.VI+ API.</p></blockquote></div>",
+        "description": "<p>Returns vulnerability definitions that match given search criteria for only <b>Qualys</b> customers.</p><div class=\"pin\"><blockquote class=\"callout callout_warn\" theme=\"🚧\"><h3 class=\"callout-heading false\"><span class=\"callout-icon\">🚧</span><p>Restricted Access</p></h3><p>This API endpoint is a premium feature and requires access to the Kenna.VI+ API.</p></blockquote></div>",
         "operationId": "search-for-vulnerability-definitions",
         "security": [
           {
@@ -17131,6 +17556,7 @@
           {
             "name": "qids",
             "in": "query",
+            "required": true,
             "description": "A comma separated list of Qualys vulnerability QIDs.",
             "schema": {
               "type": "string"
@@ -17139,7 +17565,7 @@
           {
             "name": "rce",
             "in": "query",
-            "description": "RCE is remote code execution. If RCE is true, only vulnerability definitions with true RCE are returned, similarly, if RCE is false, only vulnerability definitions with false RCE are returned. If RCE is not specified, all vulnerability definitions are returned",
+            "description": "RCE is remote code execution. If RCE is true, only vulnerability definitions with true RCE are returned, similarly, if RCE is false, only vulnerability definitions with false RCE are returned. If RCE is not specified, all vulnerability definitions are returned.",
             "schema": {
               "type": "boolean"
             }
@@ -17163,221 +17589,225 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "qids": {
-                    "375445": {
-                      "CVE-2021-21206": {
-                        "exploits": [
-                          {
-                            "created_at": "2021-04-21T08:00:16Z",
-                            "external_id": null,
-                            "name": "Script-JS.Exploit.CVE-2021-21206",
-                            "source": "reversing_labs",
-                            "url": null
-                          }
-                        ],
-                        "fixes": [
-                          {
-                            "external_id": "375445",
-                            "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
-                            "product": "chrome",
-                            "published_at": "2021-04-14T05:14:45Z"
-                          },
-                          {
-                            "external_id": "google-chrome-cve-2021-21206",
-                            "url": null,
-                            "product": null,
-                            "published_at": "2021-04-14T00:00:00Z"
-                          },
-                          {
-                            "external_id": "375446",
-                            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
-                            "product": "edge_chromium",
-                            "published_at": "2021-04-14T05:14:45Z"
-                          },
-                          {
-                            "external_id": "710018",
-                            "url": "https://security.gentoo.org/glsa/202104-08",
-                            "product": "None",
-                            "published_at": "2021-05-05T14:04:31Z"
-                          },
-                          {
-                            "external_id": "281203",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-35d2bb4627",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          },
-                          {
-                            "external_id": "281204",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-ff893e12c5",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          },
-                          {
-                            "external_id": "281205",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-c3754414e7",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          }
-                        ],
-                        "threat_actors": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "qids": {
+                        "375445": {
+                          "CVE-2021-21206": {
+                            "exploits": [
+                              {
+                                "created_at": "2021-04-21T08:00:16Z",
+                                "external_id": null,
+                                "name": "Script-JS.Exploit.CVE-2021-21206",
+                                "source": "reversing_labs",
+                                "url": null
+                              }
+                            ],
+                            "fixes": [
+                              {
+                                "external_id": "375445",
+                                "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
+                                "product": "chrome",
+                                "published_at": "2021-04-14T05:14:45Z"
+                              },
+                              {
+                                "external_id": "google-chrome-cve-2021-21206",
+                                "url": null,
+                                "product": null,
+                                "published_at": "2021-04-14T00:00:00Z"
+                              },
+                              {
+                                "external_id": "375446",
+                                "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
+                                "product": "edge_chromium",
+                                "published_at": "2021-04-14T05:14:45Z"
+                              },
+                              {
+                                "external_id": "710018",
+                                "url": "https://security.gentoo.org/glsa/202104-08",
+                                "product": "None",
+                                "published_at": "2021-05-05T14:04:31Z"
+                              },
+                              {
+                                "external_id": "281203",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-35d2bb4627",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              },
+                              {
+                                "external_id": "281204",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-ff893e12c5",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              },
+                              {
+                                "external_id": "281205",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-c3754414e7",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              }
+                            ],
+                            "threat_actors": [
 
-                        ],
-                        "created_at": "2020-12-22T00:00:07Z",
-                        "daily_trend": "holding",
-                        "predicted_exploitable": false,
-                        "predicted_exploitable_confidence": 0.000720525,
-                        "successful_exploitations": 8702,
-                        "velocity_day": 1,
-                        "velocity_month": 15,
-                        "velocity_week": 5,
-                        "cve_id": "CVE-2021-21206",
-                        "cvss_score": 6.8,
-                        "cvss_exploit_subscore": 8.6,
-                        "cvss_impact_subscore": 6.4,
-                        "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                        "cvss_temporal_score": 5,
-                        "cvss_v3_score": 8.8,
-                        "cvss_v3_exploit_subscore": 2.8,
-                        "cvss_v3_impact_subscore": 5.9,
-                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                        "cvss_v3_temporal_score": null,
-                        "last_modified": "2021-06-03T14:27:00Z",
-                        "published": "2021-04-26T17:15:00Z",
-                        "vulnerable_products": [
-                          "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:32:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:33:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:34:*:*:*:*:*:*:*"
-                        ],
-                        "id": 2853560,
-                        "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                        "cvss_access_complexity": "Medium",
-                        "cvss_access_vector": "Network",
-                        "cvss_authentication": "None required",
-                        "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                        "risk_meter_score": 77.1296,
-                        "cvss_availability_impact": "Partial",
-                        "cvss_confidentiality_impact": "Partial",
-                        "cvss_integrity_impact": "Partial",
-                        "easily_exploitable": true,
-                        "malware_exploitable": true,
-                        "active_internet_breach": true,
-                        "malware_count": 1,
-                        "popular_target": true,
-                        "remote_code_execution": false,
-                        "pre_nvd_chatter": false,
-                        "state": "published"
-                      },
-                      "CVE-2021-21220": {
-                        "exploits": [
-                          {
-                            "created_at": "2021-05-01T05:13:53Z",
-                            "external_id": "exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation",
-                            "name": "Google Chrome versions before 89.0.4389.128 V8 XOR Typer Out-Of-Bounds Access RCE",
-                            "source": "metasploit",
-                            "url": "http://www.rapid7.com/db/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation"
+                            ],
+                            "created_at": "2020-12-22T00:00:07Z",
+                            "daily_trend": "holding",
+                            "predicted_exploitable": false,
+                            "predicted_exploitable_confidence": 0.000720525,
+                            "successful_exploitations": 8702,
+                            "velocity_day": 1,
+                            "velocity_month": 15,
+                            "velocity_week": 5,
+                            "cve_id": "CVE-2021-21206",
+                            "cvss_score": 6.8,
+                            "cvss_exploit_subscore": 8.6,
+                            "cvss_impact_subscore": 6.4,
+                            "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                            "cvss_temporal_score": 5,
+                            "cvss_v3_score": 8.8,
+                            "cvss_v3_exploit_subscore": 2.8,
+                            "cvss_v3_impact_subscore": 5.9,
+                            "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                            "cvss_v3_temporal_score": null,
+                            "last_modified": "2021-06-03T14:27:00Z",
+                            "published": "2021-04-26T17:15:00Z",
+                            "vulnerable_products": [
+                              "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:32:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:33:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:34:*:*:*:*:*:*:*"
+                            ],
+                            "id": 2853560,
+                            "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                            "cvss_access_complexity": "Medium",
+                            "cvss_access_vector": "Network",
+                            "cvss_authentication": "None required",
+                            "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                            "risk_meter_score": 77.1296,
+                            "cvss_availability_impact": "Partial",
+                            "cvss_confidentiality_impact": "Partial",
+                            "cvss_integrity_impact": "Partial",
+                            "easily_exploitable": true,
+                            "malware_exploitable": true,
+                            "active_internet_breach": true,
+                            "malware_count": 1,
+                            "popular_target": true,
+                            "remote_code_execution": false,
+                            "pre_nvd_chatter": false,
+                            "state": "published"
                           },
-                          {
-                            "created_at": "2021-05-02T07:09:25Z",
-                            "external_id": null,
-                            "name": "Script-JS.Exploit.CVE-2021-21220",
-                            "source": "reversing_labs",
-                            "url": null
-                          }
-                        ],
-                        "fixes": [
-                          {
-                            "external_id": "375445",
-                            "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
-                            "product": "chrome",
-                            "published_at": "2021-04-14T05:14:45Z"
-                          },
-                          {
-                            "external_id": "google-chrome-cve-2021-21220",
-                            "url": null,
-                            "product": null,
-                            "published_at": "2021-04-14T00:00:00Z"
-                          },
-                          {
-                            "external_id": "375446",
-                            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
-                            "product": "edge_chromium",
-                            "published_at": "2021-04-14T05:14:45Z"
-                          },
-                          {
-                            "external_id": "710018",
-                            "url": "https://security.gentoo.org/glsa/202104-08",
-                            "product": "None",
-                            "published_at": "2021-05-05T14:04:31Z"
-                          },
-                          {
-                            "external_id": "281203",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-35d2bb4627",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          },
-                          {
-                            "external_id": "281204",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-ff893e12c5",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          },
-                          {
-                            "external_id": "281205",
-                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-c3754414e7",
-                            "product": "chromium",
-                            "published_at": "2021-06-03T13:32:13Z"
-                          }
-                        ],
-                        "threat_actors": [
+                          "CVE-2021-21220": {
+                            "exploits": [
+                              {
+                                "created_at": "2021-05-01T05:13:53Z",
+                                "external_id": "exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation",
+                                "name": "Google Chrome versions before 89.0.4389.128 V8 XOR Typer Out-Of-Bounds Access RCE",
+                                "source": "metasploit",
+                                "url": "http://www.rapid7.com/db/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation"
+                              },
+                              {
+                                "created_at": "2021-05-02T07:09:25Z",
+                                "external_id": null,
+                                "name": "Script-JS.Exploit.CVE-2021-21220",
+                                "source": "reversing_labs",
+                                "url": null
+                              }
+                            ],
+                            "fixes": [
+                              {
+                                "external_id": "375445",
+                                "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
+                                "product": "chrome",
+                                "published_at": "2021-04-14T05:14:45Z"
+                              },
+                              {
+                                "external_id": "google-chrome-cve-2021-21220",
+                                "url": null,
+                                "product": null,
+                                "published_at": "2021-04-14T00:00:00Z"
+                              },
+                              {
+                                "external_id": "375446",
+                                "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
+                                "product": "edge_chromium",
+                                "published_at": "2021-04-14T05:14:45Z"
+                              },
+                              {
+                                "external_id": "710018",
+                                "url": "https://security.gentoo.org/glsa/202104-08",
+                                "product": "None",
+                                "published_at": "2021-05-05T14:04:31Z"
+                              },
+                              {
+                                "external_id": "281203",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-35d2bb4627",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              },
+                              {
+                                "external_id": "281204",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-ff893e12c5",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              },
+                              {
+                                "external_id": "281205",
+                                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2021-c3754414e7",
+                                "product": "chromium",
+                                "published_at": "2021-06-03T13:32:13Z"
+                              }
+                            ],
+                            "threat_actors": [
 
-                        ],
-                        "created_at": "2020-12-22T00:00:08Z",
-                        "daily_trend": "holding",
-                        "predicted_exploitable": false,
-                        "predicted_exploitable_confidence": 0.00124733,
-                        "successful_exploitations": 1133,
-                        "velocity_day": 0,
-                        "velocity_month": 59,
-                        "velocity_week": 2,
-                        "cve_id": "CVE-2021-21220",
-                        "cvss_score": 6.8,
-                        "cvss_exploit_subscore": 8.6,
-                        "cvss_impact_subscore": 6.4,
-                        "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:POC/RL:OF/RC:C",
-                        "cvss_temporal_score": 5.3,
-                        "cvss_v3_score": 8.8,
-                        "cvss_v3_exploit_subscore": 2.8,
-                        "cvss_v3_impact_subscore": 5.9,
-                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
-                        "cvss_v3_temporal_score": null,
-                        "last_modified": "2021-06-01T15:20:00Z",
-                        "published": "2021-04-26T17:15:00Z",
-                        "vulnerable_products": [
-                          "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:32:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:33:*:*:*:*:*:*:*",
-                          "cpe:2.3:o:fedoraproject:fedora:34:*:*:*:*:*:*:*"
-                        ],
-                        "id": 2853574,
-                        "cve_description": "Insufficient validation of untrusted input in V8 in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                        "cvss_access_complexity": "Medium",
-                        "cvss_access_vector": "Network",
-                        "cvss_authentication": "None required",
-                        "description": "Insufficient validation of untrusted input in V8 in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                        "risk_meter_score": 100,
-                        "cvss_availability_impact": "Partial",
-                        "cvss_confidentiality_impact": "Partial",
-                        "cvss_integrity_impact": "Partial",
-                        "easily_exploitable": true,
-                        "malware_exploitable": true,
-                        "active_internet_breach": true,
-                        "malware_count": 1,
-                        "popular_target": true,
-                        "remote_code_execution": false,
-                        "pre_nvd_chatter": false,
-                        "state": "rejected"
+                            ],
+                            "created_at": "2020-12-22T00:00:08Z",
+                            "daily_trend": "holding",
+                            "predicted_exploitable": false,
+                            "predicted_exploitable_confidence": 0.00124733,
+                            "successful_exploitations": 1133,
+                            "velocity_day": 0,
+                            "velocity_month": 59,
+                            "velocity_week": 2,
+                            "cve_id": "CVE-2021-21220",
+                            "cvss_score": 6.8,
+                            "cvss_exploit_subscore": 8.6,
+                            "cvss_impact_subscore": 6.4,
+                            "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:POC/RL:OF/RC:C",
+                            "cvss_temporal_score": 5.3,
+                            "cvss_v3_score": 8.8,
+                            "cvss_v3_exploit_subscore": 2.8,
+                            "cvss_v3_impact_subscore": 5.9,
+                            "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+                            "cvss_v3_temporal_score": null,
+                            "last_modified": "2021-06-01T15:20:00Z",
+                            "published": "2021-04-26T17:15:00Z",
+                            "vulnerable_products": [
+                              "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:32:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:33:*:*:*:*:*:*:*",
+                              "cpe:2.3:o:fedoraproject:fedora:34:*:*:*:*:*:*:*"
+                            ],
+                            "id": 2853574,
+                            "cve_description": "Insufficient validation of untrusted input in V8 in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                            "cvss_access_complexity": "Medium",
+                            "cvss_access_vector": "Network",
+                            "cvss_authentication": "None required",
+                            "description": "Insufficient validation of untrusted input in V8 in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                            "risk_meter_score": 100,
+                            "cvss_availability_impact": "Partial",
+                            "cvss_confidentiality_impact": "Partial",
+                            "cvss_integrity_impact": "Partial",
+                            "easily_exploitable": true,
+                            "malware_exploitable": true,
+                            "active_internet_breach": true,
+                            "malware_count": 1,
+                            "popular_target": true,
+                            "remote_code_execution": false,
+                            "pre_nvd_chatter": false,
+                            "state": "rejected"
+                          }
+                        }
                       }
                     }
                   }
@@ -17451,51 +17881,55 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "example": {
-                  "trends": [
-                    {
-                      "id": 5,
-                      "vulnerability_definition_id": 1,
-                      "cve_identifier": "CVE-1234-12345",
-                      "kind": "velocity",
-                      "last_day": 96,
-                      "last_week": 73,
-                      "last_month": 50,
-                      "percentage_change_per_day": "66.97",
-                      "percentage_change_per_week": "78.65",
-                      "percentage_change_per_month": "71.36",
-                      "daily_trend": "UP",
-                      "last_event_at": "2022-02-16T13:47:22.000Z"
-                    },
-                    {
-                      "id": 1,
-                      "vulnerability_definition_id": 1,
-                      "cve_identifier": "CVE-1234-12345",
-                      "kind": "velocity",
-                      "last_day": 64,
-                      "last_week": 72,
-                      "last_month": 24,
-                      "percentage_change_per_day": "76.7",
-                      "percentage_change_per_week": "59.91",
-                      "percentage_change_per_month": "95.65",
-                      "daily_trend": "DOWN",
-                      "last_event_at": "2022-02-16T13:47:22.000Z"
-                    },
-                    {
-                      "id": 2,
-                      "vulnerability_definition_id": 3,
-                      "cve_identifier": "CVE-1234-12345",
-                      "kind": "velocity",
-                      "last_day": 18,
-                      "last_week": 66,
-                      "last_month": 5,
-                      "percentage_change_per_day": "19.85",
-                      "percentage_change_per_week": "16.98",
-                      "percentage_change_per_month": "86.32",
-                      "daily_trend": "UP",
-                      "last_event_at": "2022-02-16T13:47:22.000Z"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "trends": [
+                        {
+                          "id": 5,
+                          "vulnerability_definition_id": 1,
+                          "cve_identifier": "CVE-1234-12345",
+                          "kind": "velocity",
+                          "last_day": 96,
+                          "last_week": 73,
+                          "last_month": 50,
+                          "percentage_change_per_day": "66.97",
+                          "percentage_change_per_week": "78.65",
+                          "percentage_change_per_month": "71.36",
+                          "daily_trend": "UP",
+                          "last_event_at": "2022-02-16T13:47:22.000Z"
+                        },
+                        {
+                          "id": 1,
+                          "vulnerability_definition_id": 1,
+                          "cve_identifier": "CVE-1234-12345",
+                          "kind": "velocity",
+                          "last_day": 64,
+                          "last_week": 72,
+                          "last_month": 24,
+                          "percentage_change_per_day": "76.7",
+                          "percentage_change_per_week": "59.91",
+                          "percentage_change_per_month": "95.65",
+                          "daily_trend": "DOWN",
+                          "last_event_at": "2022-02-16T13:47:22.000Z"
+                        },
+                        {
+                          "id": 2,
+                          "vulnerability_definition_id": 3,
+                          "cve_identifier": "CVE-1234-12345",
+                          "kind": "velocity",
+                          "last_day": 18,
+                          "last_week": 66,
+                          "last_month": 5,
+                          "percentage_change_per_day": "19.85",
+                          "percentage_change_per_week": "16.98",
+                          "percentage_change_per_month": "86.32",
+                          "daily_trend": "UP",
+                          "last_event_at": "2022-02-16T13:47:22.000Z"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/trends_schema"
@@ -17507,10 +17941,14 @@
             "description": "Bad Request",
             "content": {
               "application/json": {
-                "example": {
-                  "error": "invalid_vuln_trends_params",
-                  "message": "Invalid Vulnerability Trends params: { trend: chatter, sort: weak }",
-                  "success": false
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "error": "invalid_vuln_trends_params",
+                      "message": "Invalid Vulnerability Trends params: { trend: chatter, sort: weak }",
+                      "success": false
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/error_response"
@@ -17541,57 +17979,61 @@
             "description": "OK. Returns a gzipped file. Schema is for unzipped file.",
             "content": {
               "application/json": {
-                "example": {
-                  "active_internet_breach": false,
-                  "created_at": "2009-04-23T04:31:18+0000",
-                  "cve_description": "Vulnerability in rcp on SunOS 4.0.x allows remote attackers from trusted hosts toexecute arbitrary commands as root, possibly related to the configuration of the nobody user.",
-                  "cve_id": "CVE-1999-1467",
-                  "cvss_access_complexity": "Low",
-                  "cvss_access_vector": "Network",
-                  "cvss_authentication": "None required",
-                  "cvss_availability_impact": "Complete",
-                  "cvss_confidentiality_impact": "Complete",
-                  "cvss_exploit_subscore": 10.0,
-                  "cvss_impact_subscore": 10.0,
-                  "cvss_integrity_impact": "Complete",
-                  "cvss_score": 10.0,
-                  "cvss_temporal_score": 10.0,
-                  "cvss_vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-                  "daily_trend": "holding",
-                  "description": "Vulnerability in rcp on SunOS 4.0.x allows remote attackers from trusted hosts to execute arbitrary commands as root, possibly related to the configuration of the nobody user.",
-                  "easily_exploitable": false,
-                  "exploits": [
-                    {
-                    }
-                  ],
-                  "fixes": [
-                    {
-                    }
-                  ],
-                  "malware_count": 0,
-                  "malware_exploitable": false,
-                  "popular_target": false,
-                  "pre_nvd_chatter": false,
-                  "predicted_exploitable": false,
-                  "predicted_exploitable_confidence": 0.221262,
-                  "published": "1989-10-26T04:00:00+0000",
-                  "last_modified": "2017-12-19T02:29:00+0000",
-                  "remote_code_execution": true,
-                  "risk_meter_score": 36.4585,
-                  "successful_exploitations": 0,
-                  "threat_actors": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "active_internet_breach": false,
+                      "created_at": "2009-04-23T04:31:18+0000",
+                      "cve_description": "Vulnerability in rcp on SunOS 4.0.x allows remote attackers from trusted hosts toexecute arbitrary commands as root, possibly related to the configuration of the nobody user.",
+                      "cve_id": "CVE-1999-1467",
+                      "cvss_access_complexity": "Low",
+                      "cvss_access_vector": "Network",
+                      "cvss_authentication": "None required",
+                      "cvss_availability_impact": "Complete",
+                      "cvss_confidentiality_impact": "Complete",
+                      "cvss_exploit_subscore": 10.0,
+                      "cvss_impact_subscore": 10.0,
+                      "cvss_integrity_impact": "Complete",
+                      "cvss_score": 10.0,
+                      "cvss_temporal_score": 10.0,
+                      "cvss_vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+                      "daily_trend": "holding",
+                      "description": "Vulnerability in rcp on SunOS 4.0.x allows remote attackers from trusted hosts to execute arbitrary commands as root, possibly related to the configuration of the nobody user.",
+                      "easily_exploitable": false,
+                      "exploits": [
+                        {
+                        }
+                      ],
+                      "fixes": [
+                        {
+                        }
+                      ],
+                      "malware_count": 0,
+                      "malware_exploitable": false,
+                      "popular_target": false,
+                      "pre_nvd_chatter": false,
+                      "predicted_exploitable": false,
+                      "predicted_exploitable_confidence": 0.221262,
+                      "published": "1989-10-26T04:00:00+0000",
+                      "last_modified": "2017-12-19T02:29:00+0000",
+                      "remote_code_execution": true,
+                      "risk_meter_score": 36.4585,
+                      "successful_exploitations": 0,
+                      "threat_actors": [
 
-                  ],
-                  "velocity_day": 0,
-                  "velocity_month": 0,
-                  "velocity_week": 0,
-                  "vulnerable_products": [
-                    "cpe:2.3:o:sun:sunos:4.0:*:*:*:*:*:*:*",
-                    "cpe:2.3:o:sun:sunos:4.0.1:*:*:*:*:*:*:*",
-                    "cpe:2.3:o:sun:sunos:4.0.2:*:*:*:*:*:*:*",
-                    "cpe:2.3:o:sun:sunos:4.0.3:*:*:*:*:*:*:*",
-                    "cpe:2.3:o:sun:sunos:4.0.3c:*:*:*:*:*:*:*"
-                  ]
+                      ],
+                      "velocity_day": 0,
+                      "velocity_month": 0,
+                      "velocity_week": 0,
+                      "vulnerable_products": [
+                        "cpe:2.3:o:sun:sunos:4.0:*:*:*:*:*:*:*",
+                        "cpe:2.3:o:sun:sunos:4.0.1:*:*:*:*:*:*:*",
+                        "cpe:2.3:o:sun:sunos:4.0.2:*:*:*:*:*:*:*",
+                        "cpe:2.3:o:sun:sunos:4.0.3:*:*:*:*:*:*:*",
+                        "cpe:2.3:o:sun:sunos:4.0.3c:*:*:*:*:*:*:*"
+                      ]
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/vulnerability_definition_schema"
@@ -17684,216 +18126,220 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "CVE-2021-21206": {
-                    "exploits": [
-                      {
-                        "created_at": "2021-04-21T08:00:16Z",
-                        "external_id": null,
-                        "name": "Script-JS.Exploit.CVE-2021-21206",
-                        "url": null
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "CVE-2021-21206": {
+                        "exploits": [
+                          {
+                            "created_at": "2021-04-21T08:00:16Z",
+                            "external_id": null,
+                            "name": "Script-JS.Exploit.CVE-2021-21206",
+                            "url": null
+                          }
+                        ],
+                        "fixes": [
+                          {
+                            "external_id": "375445",
+                            "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
+                            "product": "chrome",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "google-chrome-cve-2021-21206",
+                            "url": null,
+                            "product": null,
+                            "published_at": "2021-04-14T00:00:00Z"
+                          },
+                          {
+                            "external_id": "375446",
+                            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
+                            "product": "edge_chromium",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "710018",
+                            "url": "https://security.gentoo.org/glsa/202104-08",
+                            "product": "None",
+                            "published_at": "2021-05-05T14:04:31Z"
+                          }
+                        ],
+                        "threat_actors": [
+
+                        ],
+                        "created_at": "2020-12-22T00:00:07Z",
+                        "daily_trend": "down",
+                        "predicted_exploitable": false,
+                        "predicted_exploitable_confidence": 0.000720525,
+                        "successful_exploitations": 6657,
+                        "velocity_day": 12,
+                        "velocity_month": 6657,
+                        "velocity_week": 684,
+                        "cve_id": "CVE-2021-21206",
+                        "cvss_score": 6.8,
+                        "cvss_exploit_subscore": 8.6,
+                        "cvss_impact_subscore": 6.4,
+                        "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                        "cvss_temporal_score": 5.0,
+                        "cvss_v3_score": 8.8,
+                        "cvss_v3_exploit_subscore": 2.8,
+                        "cvss_v3_impact_subscore": 5.9,
+                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                        "cvss_v3_temporal_score": null,
+                        "last_modified": "2021-05-01T02:15:00Z",
+                        "published": "2021-04-26T17:15:00Z",
+                        "vulnerable_products": [
+                          "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
+                        ],
+                        "id": 2853560,
+                        "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "cvss_access_complexity": "Medium",
+                        "cvss_access_vector": "Network",
+                        "cvss_authentication": "None required",
+                        "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "risk_meter_score": 77.1296,
+                        "cvss_availability_impact": "Partial",
+                        "cvss_confidentiality_impact": "Partial",
+                        "cvss_integrity_impact": "Partial",
+                        "easily_exploitable": true,
+                        "malware_exploitable": true,
+                        "active_internet_breach": true,
+                        "malware_count": 1,
+                        "chatter_count": 2,
+                        "popular_target": true,
+                        "remote_code_execution": false,
+                        "pre_nvd_chatter": false,
+                        "state": "published",
+                        "stride_threat": [
+                          "tampering",
+                          "information disclosure"
+                        ],
+                        "vulnerability_type": [
+
+                        ],
+                        "exploitation_methodology": [
+
+                        ],
+                        "affected_source_file_module": [
+
+                        ]
+                      },
+                      "CVE-2021-22893": {
+                        "exploits": [
+
+                        ],
+                        "fixes": [
+                          {
+                            "external_id": "38838",
+                            "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44784",
+                            "product": "pulse_connect_secure",
+                            "published_at": "2021-04-21T05:51:36Z"
+                          },
+                          {
+                            "external_id": "pulse-secure-pulse-connect-secure-cve-2021-22893",
+                            "url": null,
+                            "product": null,
+                            "published_at": "2021-04-19T00:00:00Z"
+                          }
+                        ],
+                        "threat_actors": [
+
+                        ],
+                        "created_at": "2021-01-06T23:00:12Z",
+                        "daily_trend": "holding",
+                        "predicted_exploitable": false,
+                        "predicted_exploitable_confidence": 0.0457823,
+                        "successful_exploitations": 1,
+                        "velocity_day": 0,
+                        "velocity_month": 1,
+                        "velocity_week": 0,
+                        "cve_id": "CVE-2021-22893",
+                        "cvss_score": 7.5,
+                        "cvss_exploit_subscore": 10.0,
+                        "cvss_impact_subscore": 6.4,
+                        "cvss_vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                        "cvss_temporal_score": 5.5,
+                        "cvss_v3_score": 10.0,
+                        "cvss_v3_exploit_subscore": 3.9,
+                        "cvss_v3_impact_subscore": 6.0,
+                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                        "cvss_v3_temporal_score": null,
+                        "last_modified": "2021-04-28T17:52:00Z",
+                        "published": "2021-04-23T17:15:00Z",
+                        "vulnerable_products": [
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:-:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.5:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r5.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r6.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:-:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r5:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r6:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r7:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.2:*:*:*:*:*:*"
+                        ],
+                        "id": 2959132,
+                        "cve_description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
+                        "cvss_access_complexity": "Low",
+                        "cvss_access_vector": "Network",
+                        "cvss_authentication": "None required",
+                        "description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
+                        "risk_meter_score": 66.7067,
+                        "cvss_availability_impact": "Partial",
+                        "cvss_confidentiality_impact": "Partial",
+                        "cvss_integrity_impact": "Partial",
+                        "easily_exploitable": false,
+                        "malware_exploitable": false,
+                        "active_internet_breach": true,
+                        "malware_count": 0,
+                        "chatter_count": 1,
+                        "popular_target": false,
+                        "remote_code_execution": true,
+                        "pre_nvd_chatter": false,
+                        "state": "published",
+                        "stride_threat": [
+                          "denial of Service"
+                        ],
+                        "vulnerability_type": [
+                          "Heap-based Buffer Overflow",
+                          "Denial of Service",
+                          "DoS"
+                        ],
+                        "exploitation_methodology": [
+                          "configured with storm control profiling"
+                        ],
+                        "affected_source_file_module": [
+                          "packet forwarding engine",
+                          "PFE"
+                        ]
                       }
-                    ],
-                    "fixes": [
-                      {
-                        "external_id": "375445",
-                        "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
-                        "product": "chrome",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "google-chrome-cve-2021-21206",
-                        "url": null,
-                        "product": null,
-                        "published_at": "2021-04-14T00:00:00Z"
-                      },
-                      {
-                        "external_id": "375446",
-                        "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
-                        "product": "edge_chromium",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "710018",
-                        "url": "https://security.gentoo.org/glsa/202104-08",
-                        "product": "None",
-                        "published_at": "2021-05-05T14:04:31Z"
-                      }
-                    ],
-                    "threat_actors": [
-
-                    ],
-                    "created_at": "2020-12-22T00:00:07Z",
-                    "daily_trend": "down",
-                    "predicted_exploitable": false,
-                    "predicted_exploitable_confidence": 0.000720525,
-                    "successful_exploitations": 6657,
-                    "velocity_day": 12,
-                    "velocity_month": 6657,
-                    "velocity_week": 684,
-                    "cve_id": "CVE-2021-21206",
-                    "cvss_score": 6.8,
-                    "cvss_exploit_subscore": 8.6,
-                    "cvss_impact_subscore": 6.4,
-                    "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                    "cvss_temporal_score": 5.0,
-                    "cvss_v3_score": 8.8,
-                    "cvss_v3_exploit_subscore": 2.8,
-                    "cvss_v3_impact_subscore": 5.9,
-                    "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                    "cvss_v3_temporal_score": null,
-                    "last_modified": "2021-05-01T02:15:00Z",
-                    "published": "2021-04-26T17:15:00Z",
-                    "vulnerable_products": [
-                      "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
-                    ],
-                    "id": 2853560,
-                    "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "cvss_access_complexity": "Medium",
-                    "cvss_access_vector": "Network",
-                    "cvss_authentication": "None required",
-                    "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "risk_meter_score": 77.1296,
-                    "cvss_availability_impact": "Partial",
-                    "cvss_confidentiality_impact": "Partial",
-                    "cvss_integrity_impact": "Partial",
-                    "easily_exploitable": true,
-                    "malware_exploitable": true,
-                    "active_internet_breach": true,
-                    "malware_count": 1,
-                    "chatter_count": 2,
-                    "popular_target": true,
-                    "remote_code_execution": false,
-                    "pre_nvd_chatter": false,
-                    "state": "published",
-                    "stride_threat": [
-                      "tampering",
-                      "information disclosure"
-                    ],
-                    "vulnerability_type": [
-
-                    ],
-                    "exploitation_methodology": [
-
-                    ],
-                    "affected_source_file_module": [
-
-                    ]
-                  },
-                  "CVE-2021-22893": {
-                    "exploits": [
-
-                    ],
-                    "fixes": [
-                      {
-                        "external_id": "38838",
-                        "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44784",
-                        "product": "pulse_connect_secure",
-                        "published_at": "2021-04-21T05:51:36Z"
-                      },
-                      {
-                        "external_id": "pulse-secure-pulse-connect-secure-cve-2021-22893",
-                        "url": null,
-                        "product": null,
-                        "published_at": "2021-04-19T00:00:00Z"
-                      }
-                    ],
-                    "threat_actors": [
-
-                    ],
-                    "created_at": "2021-01-06T23:00:12Z",
-                    "daily_trend": "holding",
-                    "predicted_exploitable": false,
-                    "predicted_exploitable_confidence": 0.0457823,
-                    "successful_exploitations": 1,
-                    "velocity_day": 0,
-                    "velocity_month": 1,
-                    "velocity_week": 0,
-                    "cve_id": "CVE-2021-22893",
-                    "cvss_score": 7.5,
-                    "cvss_exploit_subscore": 10.0,
-                    "cvss_impact_subscore": 6.4,
-                    "cvss_vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                    "cvss_temporal_score": 5.5,
-                    "cvss_v3_score": 10.0,
-                    "cvss_v3_exploit_subscore": 3.9,
-                    "cvss_v3_impact_subscore": 6.0,
-                    "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                    "cvss_v3_temporal_score": null,
-                    "last_modified": "2021-04-28T17:52:00Z",
-                    "published": "2021-04-23T17:15:00Z",
-                    "vulnerable_products": [
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:-:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.5:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r5.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r6.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:-:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r5:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r6:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r7:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.2:*:*:*:*:*:*"
-                    ],
-                    "id": 2959132,
-                    "cve_description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
-                    "cvss_access_complexity": "Low",
-                    "cvss_access_vector": "Network",
-                    "cvss_authentication": "None required",
-                    "description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
-                    "risk_meter_score": 66.7067,
-                    "cvss_availability_impact": "Partial",
-                    "cvss_confidentiality_impact": "Partial",
-                    "cvss_integrity_impact": "Partial",
-                    "easily_exploitable": false,
-                    "malware_exploitable": false,
-                    "active_internet_breach": true,
-                    "malware_count": 0,
-                    "chatter_count": 1,
-                    "popular_target": false,
-                    "remote_code_execution": true,
-                    "pre_nvd_chatter": false,
-                    "state": "published",
-                    "stride_threat": [
-                      "denial of Service"
-                    ],
-                    "vulnerability_type": [
-                      "Heap-based Buffer Overflow",
-                      "Denial of Service",
-                      "DoS"
-                    ],
-                    "exploitation_methodology": [
-                      "configured with storm control profiling"
-                    ],
-                    "affected_source_file_module": [
-                      "packet forwarding engine",
-                      "PFE"
-                    ]
+                    }
                   }
                 },
                 "schema": {
@@ -17966,190 +18412,194 @@
             "description": "200",
             "content": {
               "application/json": {
-                "example": {
-                  "CVE-2021-21206": {
-                    "exploits": [
-                      {
-                        "created_at": "2021-04-21T08:00:16Z",
-                        "external_id": null,
-                        "name": "Script-JS.Exploit.CVE-2021-21206",
-                        "url": null
-                      }
-                    ],
-                    "fixes": [
-                      {
-                        "external_id": "375445",
-                        "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
-                        "product": "chrome",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "google-chrome-cve-2021-21206",
-                        "url": null,
-                        "product": null,
-                        "published_at": "2021-04-14T00:00:00Z"
-                      },
-                      {
-                        "external_id": "375446",
-                        "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
-                        "product": "edge_chromium",
-                        "published_at": "2021-04-14T05:14:45Z"
-                      },
-                      {
-                        "external_id": "710018",
-                        "url": "https://security.gentoo.org/glsa/202104-08",
-                        "product": "None",
-                        "published_at": "2021-05-05T14:04:31Z"
-                      }
-                    ],
-                    "threat_actors": [
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "CVE-2021-21206": {
+                        "exploits": [
+                          {
+                            "created_at": "2021-04-21T08:00:16Z",
+                            "external_id": null,
+                            "name": "Script-JS.Exploit.CVE-2021-21206",
+                            "url": null
+                          }
+                        ],
+                        "fixes": [
+                          {
+                            "external_id": "375445",
+                            "url": "https://chromereleases.googleblog.com/2021/04/stable-channel-update-for-desktop.html",
+                            "product": "chrome",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "google-chrome-cve-2021-21206",
+                            "url": null,
+                            "product": null,
+                            "published_at": "2021-04-14T00:00:00Z"
+                          },
+                          {
+                            "external_id": "375446",
+                            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21206",
+                            "product": "edge_chromium",
+                            "published_at": "2021-04-14T05:14:45Z"
+                          },
+                          {
+                            "external_id": "710018",
+                            "url": "https://security.gentoo.org/glsa/202104-08",
+                            "product": "None",
+                            "published_at": "2021-05-05T14:04:31Z"
+                          }
+                        ],
+                        "threat_actors": [
 
-                    ],
-                    "created_at": "2020-12-22T00:00:07Z",
-                    "daily_trend": "down",
-                    "predicted_exploitable": false,
-                    "predicted_exploitable_confidence": 0.000720525,
-                    "successful_exploitations": 6657,
-                    "velocity_day": 12,
-                    "velocity_month": 6657,
-                    "velocity_week": 684,
-                    "cve_id": "CVE-2021-21206",
-                    "cvss_score": 6.8,
-                    "cvss_exploit_subscore": 8.6,
-                    "cvss_impact_subscore": 6.4,
-                    "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                    "cvss_temporal_score": 5.0,
-                    "cvss_v3_score": 8.8,
-                    "cvss_v3_exploit_subscore": 2.8,
-                    "cvss_v3_impact_subscore": 5.9,
-                    "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                    "cvss_v3_temporal_score": null,
-                    "last_modified": "2021-05-01T02:15:00Z",
-                    "published": "2021-04-26T17:15:00Z",
-                    "vulnerable_products": [
-                      "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
-                    ],
-                    "id": 2853560,
-                    "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "cvss_access_complexity": "Medium",
-                    "cvss_access_vector": "Network",
-                    "cvss_authentication": "None required",
-                    "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
-                    "risk_meter_score": 77.1296,
-                    "realtime_score": 90.3672,
-                    "cvss_availability_impact": "Partial",
-                    "cvss_confidentiality_impact": "Partial",
-                    "cvss_integrity_impact": "Partial",
-                    "easily_exploitable": true,
-                    "malware_exploitable": true,
-                    "active_internet_breach": true,
-                    "malware_count": 1,
-                    "chatter_count": 2,
-                    "popular_target": true,
-                    "remote_code_execution": false,
-                    "pre_nvd_chatter": false,
-                    "state": "published"
-                  },
-                  "CVE-2021-22893": {
-                    "exploits": [
-
-                    ],
-                    "fixes": [
-                      {
-                        "external_id": "38838",
-                        "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44784",
-                        "product": "pulse_connect_secure",
-                        "published_at": "2021-04-21T05:51:36Z"
+                        ],
+                        "created_at": "2020-12-22T00:00:07Z",
+                        "daily_trend": "down",
+                        "predicted_exploitable": false,
+                        "predicted_exploitable_confidence": 0.000720525,
+                        "successful_exploitations": 6657,
+                        "velocity_day": 12,
+                        "velocity_month": 6657,
+                        "velocity_week": 684,
+                        "cve_id": "CVE-2021-21206",
+                        "cvss_score": 6.8,
+                        "cvss_exploit_subscore": 8.6,
+                        "cvss_impact_subscore": 6.4,
+                        "cvss_vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                        "cvss_temporal_score": 5.0,
+                        "cvss_v3_score": 8.8,
+                        "cvss_v3_exploit_subscore": 2.8,
+                        "cvss_v3_impact_subscore": 5.9,
+                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                        "cvss_v3_temporal_score": null,
+                        "last_modified": "2021-05-01T02:15:00Z",
+                        "published": "2021-04-26T17:15:00Z",
+                        "vulnerable_products": [
+                          "cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"
+                        ],
+                        "id": 2853560,
+                        "cve_description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "cvss_access_complexity": "Medium",
+                        "cvss_access_vector": "Network",
+                        "cvss_authentication": "None required",
+                        "description": "Use after free in Blink in Google Chrome prior to 89.0.4389.128 allowed a remote attacker to potentially exploit heap corruption via a crafted HTML page.",
+                        "risk_meter_score": 77.1296,
+                        "realtime_score": 90.3672,
+                        "cvss_availability_impact": "Partial",
+                        "cvss_confidentiality_impact": "Partial",
+                        "cvss_integrity_impact": "Partial",
+                        "easily_exploitable": true,
+                        "malware_exploitable": true,
+                        "active_internet_breach": true,
+                        "malware_count": 1,
+                        "chatter_count": 2,
+                        "popular_target": true,
+                        "remote_code_execution": false,
+                        "pre_nvd_chatter": false,
+                        "state": "published"
                       },
-                      {
-                        "external_id": "pulse-secure-pulse-connect-secure-cve-2021-22893",
-                        "url": null,
-                        "product": null,
-                        "published_at": "2021-04-19T00:00:00Z"
-                      }
-                    ],
-                    "threat_actors": [
+                      "CVE-2021-22893": {
+                        "exploits": [
 
-                    ],
-                    "created_at": "2021-01-06T23:00:12Z",
-                    "daily_trend": "holding",
-                    "predicted_exploitable": false,
-                    "predicted_exploitable_confidence": 0.0457823,
-                    "successful_exploitations": 1,
-                    "velocity_day": 0,
-                    "velocity_month": 1,
-                    "velocity_week": 0,
-                    "cve_id": "CVE-2021-22893",
-                    "cvss_score": 7.5,
-                    "cvss_exploit_subscore": 10.0,
-                    "cvss_impact_subscore": 6.4,
-                    "cvss_vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
-                    "cvss_temporal_score": 5.5,
-                    "cvss_v3_score": 10.0,
-                    "cvss_v3_exploit_subscore": 3.9,
-                    "cvss_v3_impact_subscore": 6.0,
-                    "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
-                    "cvss_v3_temporal_score": null,
-                    "last_modified": "2021-04-28T17:52:00Z",
-                    "published": "2021-04-23T17:15:00Z",
-                    "vulnerable_products": [
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:-:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.5:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r5.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r6.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:-:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.0:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.3:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r5:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r6:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r7:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.2:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.4:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.1:*:*:*:*:*:*",
-                      "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.2:*:*:*:*:*:*"
-                    ],
-                    "id": 2959132,
-                    "cve_description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
-                    "cvss_access_complexity": "Low",
-                    "cvss_access_vector": "Network",
-                    "cvss_authentication": "None required",
-                    "description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
-                    "risk_meter_score": 66.7067,
-                    "realtime_score": 70.6859,
-                    "cvss_availability_impact": "Partial",
-                    "cvss_confidentiality_impact": "Partial",
-                    "cvss_integrity_impact": "Partial",
-                    "easily_exploitable": false,
-                    "malware_exploitable": false,
-                    "active_internet_breach": true,
-                    "malware_count": 0,
-                    "chatter_count": 1,
-                    "popular_target": false,
-                    "remote_code_execution": true,
-                    "pre_nvd_chatter": false,
-                    "state": "published"
+                        ],
+                        "fixes": [
+                          {
+                            "external_id": "38838",
+                            "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44784",
+                            "product": "pulse_connect_secure",
+                            "published_at": "2021-04-21T05:51:36Z"
+                          },
+                          {
+                            "external_id": "pulse-secure-pulse-connect-secure-cve-2021-22893",
+                            "url": null,
+                            "product": null,
+                            "published_at": "2021-04-19T00:00:00Z"
+                          }
+                        ],
+                        "threat_actors": [
+
+                        ],
+                        "created_at": "2021-01-06T23:00:12Z",
+                        "daily_trend": "holding",
+                        "predicted_exploitable": false,
+                        "predicted_exploitable_confidence": 0.0457823,
+                        "successful_exploitations": 1,
+                        "velocity_day": 0,
+                        "velocity_month": 1,
+                        "velocity_week": 0,
+                        "cve_id": "CVE-2021-22893",
+                        "cvss_score": 7.5,
+                        "cvss_exploit_subscore": 10.0,
+                        "cvss_impact_subscore": 6.4,
+                        "cvss_vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P/E:U/RL:OF/RC:C",
+                        "cvss_temporal_score": 5.5,
+                        "cvss_v3_score": 10.0,
+                        "cvss_v3_exploit_subscore": 3.9,
+                        "cvss_v3_impact_subscore": 6.0,
+                        "cvss_v3_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
+                        "cvss_v3_temporal_score": null,
+                        "last_modified": "2021-04-28T17:52:00Z",
+                        "published": "2021-04-23T17:15:00Z",
+                        "vulnerable_products": [
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:-:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r2.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r3.5:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r4.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r5.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.0:r6.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:-:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r10.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.0:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r11.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r4.3:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r5:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r6:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r7:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.2:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r8.4:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.1:*:*:*:*:*:*",
+                          "cpe:2.3:a:pulsesecure:pulse_connect_secure:9.1:r9.2:*:*:*:*:*:*"
+                        ],
+                        "id": 2959132,
+                        "cve_description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
+                        "cvss_access_complexity": "Low",
+                        "cvss_access_vector": "Network",
+                        "cvss_authentication": "None required",
+                        "description": "Pulse Connect Secure 9.0R3/9.1R1 and higher is vulnerable to an authentication bypass vulnerability exposed by the Windows File Share Browser and Pulse Secure Collaboration features of Pulse Connect Secure that can allow an unauthenticated user to perform remote arbitrary code execution on the Pulse Connect Secure gateway. This vulnerability has been exploited in the wild.",
+                        "risk_meter_score": 66.7067,
+                        "realtime_score": 70.6859,
+                        "cvss_availability_impact": "Partial",
+                        "cvss_confidentiality_impact": "Partial",
+                        "cvss_integrity_impact": "Partial",
+                        "easily_exploitable": false,
+                        "malware_exploitable": false,
+                        "active_internet_breach": true,
+                        "malware_count": 0,
+                        "chatter_count": 1,
+                        "popular_target": false,
+                        "remote_code_execution": true,
+                        "pre_nvd_chatter": false,
+                        "state": "published"
+                      }
+                    }
                   }
                 },
                 "schema": {
@@ -18187,4 +18637,3 @@
     }
   }
 }
-


### PR DESCRIPTION
This is for VM-951 which removed the "Show Malware Family Data" API from VI+.