### PR TITLE
VM 1999 rm async queries

### DIFF
--- a/Kenna-vuln-updater/README.md
+++ b/Kenna-vuln-updater/README.md
@@ -2,19 +2,17 @@
 
 Kenna CSV import to update vulns using multi-threading
 
-This script will process a CSV file, retrieve vulnerabilities, then update data, including custom fields on each vulnerability targeted. 
+This script will process a CSV file, retrieve vulnerabilities, then update data, including custom fields on each vulnerability targeted. If the amount of vulnerabilities is over 10,000, then data exports are used.
 
-Example Usage:
+## Example Usage:
 
     Kenna-vuln-updater.rb <Kenna API token> <Import data CSV file> <meta file for custom fields> <vuln type> <vuln column in data file> <host lookup type> <IP column in data file> <hostname column in data file> <notes type> <notes value> <duedate> <status type> <status value> <vuln status> <base url>
     
-    
-Tested on:
+### Tested on:
 
     ruby 2.0.0p648 (2015-12-16 revision 53290) [universal.x86_64-darwin15]
     
-    
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
     rest-client
     json
@@ -23,11 +21,11 @@ Required Ruby classes/gems:
     thread
     monitor
     
-Expected Parameters:
+### Expected Parameters:
 
     @token = ARGV[0]
     @csv_file = ARGV[1] #source data
-    @data_column_file = ARGV[2] #custom field id's and columns with data
+    @data_column_file = ARGV[2] #custom field ID's and columns with data
     @vuln_type = ARGV[3] # cve or cwe or wasc or scanner_id or vuln_id or empty string
     @vuln_column = ARGV[4] # column that holds the vuln key or empty string
     @host_search_field = ARGV[5] #field to use first for asset match ip_address or hostname or empty string
@@ -41,7 +39,7 @@ Expected Parameters:
     @vuln_status = ARGV[13] #vuln status all, open or other for retrieval 
     ARGV.length == 15 ? @base_url = ARGV[14] : @base_url = "https://api.kennasecurity.com/"
     
-Available for Modification on the code:
+### Available for Modification on the code:
 
     @debug #set to true to have additional debug lines sent to the console
     thread_count #set to 8 by default. Too high and code will be inefficient due to retries (max API calls 3/second), too low max API limit won't be hit. 

--- a/Kenna-vuln-updater/README.md
+++ b/Kenna-vuln-updater/README.md
@@ -4,13 +4,13 @@ Kenna CSV import to update vulns using multi-threading
 
 This script will process a CSV file, retrieve vulnerabilities, then update data, including custom fields on each vulnerability targeted. If the amount of vulnerabilities is over 10,000, then data exports are used.
 
-## Example Usage:
+## Usage:
 
-    Kenna-vuln-updater.rb <Kenna API token> <Import data CSV file> <meta file for custom fields> <vuln type> <vuln column in data file> <host lookup type> <IP column in data file> <hostname column in data file> <notes type> <notes value> <duedate> <status type> <status value> <vuln status> <base url>
+    vuln-updater.rb <Kenna API token> <Import data CSV file> <meta file for custom fields> <vuln type> <vuln column in data file> <host lookup type> <IP column in data file> <hostname column in data file> <notes type> <notes value> <due date> <status type> <status value> <vuln status> [base url]
     
 ### Tested on:
 
-    ruby 2.0.0p648 (2015-12-16 revision 53290) [universal.x86_64-darwin15]
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
     
 ### Required Ruby classes/gems:
 

--- a/Kenna-vuln-updater/vuln_updater.rb
+++ b/Kenna-vuln-updater/vuln_updater.rb
@@ -1,4 +1,5 @@
 # vuln updater multi-threaded
+require 'rest-client'
 require 'json'
 require 'csv'
 require 'ipaddr'

--- a/Kenna-vuln-updater/vuln_updater.rb
+++ b/Kenna-vuln-updater/vuln_updater.rb
@@ -1,5 +1,4 @@
 # vuln updater multi-threaded
-require 'rest-client'
 require 'json'
 require 'csv'
 require 'ipaddr'

--- a/Kenna-vuln-updater/vuln_updater.rb
+++ b/Kenna-vuln-updater/vuln_updater.rb
@@ -43,7 +43,6 @@ end
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
 @custom_field_columns = [] 
 
-
 @max_retries = 5
 @debug = false
 
@@ -200,8 +199,6 @@ producer_thread = Thread.new do
 
     custom_field_string = custom_field_string[0...-1]
     
-    json_string = nil
-
     json_string = "{\"vulnerability\": {"
     if !@notes_type.empty? then
       if @notes_type == "static" then
@@ -240,6 +237,7 @@ producer_thread = Thread.new do
     #puts json_string if @debug
     #puts "#{vuln_query} = vuln_query" if @debug
 
+    # Put the row on the work queue
     work_queue << Array[hostname_query,ip_address_query,vuln_query,json_string]
     
     # Tell the consumer to check the thread array so it can attempt to schedule the
@@ -279,9 +277,8 @@ consumer_thread = Thread.new do
                                               thread["finished"].nil? == false }
       puts "i just found index = #{found_index}" if @debug
     end
+
     # Get a new unit of work from the work queue
-
-
     threads[found_index] = Thread.new(work_to_do) do
       puts "starting the thread loop" if @debug
 
@@ -352,7 +349,6 @@ consumer_thread = Thread.new do
             :headers => @headers
           ) 
           
-
           query_meta_json = JSON.parse(query_response)["meta"]
           tot_vulns = query_meta_json.fetch("total_count")
           pages = query_meta_json.fetch("pages")
@@ -395,12 +391,13 @@ consumer_thread = Thread.new do
           Thread.exit
         end
 
-        # Put the row on the work queue
+        # Determine if we're going to use "Search Vulnerabilities" API or
+        # an async query via data export APIs.
         if pages > 20 then
           async_query = true
         end
 
-        puts "async query needed #{async_query}" if @debug
+        puts "async query needed: #{async_query}" if @debug
 
         begin
 
@@ -471,8 +468,7 @@ consumer_thread = Thread.new do
             post_data(post_url,json_data)
 
           else
-            puts "starting async query" if @debug
-
+            puts "starting async query using data exports" if @debug
 
             bulk_query_json_string = "{\"asset\": {\"status\": [\"active\"]}, \"status\": [\"#{@vuln_status}\"], "
 
@@ -495,6 +491,7 @@ consumer_thread = Thread.new do
             #bulk_query_json = JSON.parse(bulk_query_json_string)
 
             puts bulk_query_json_string
+            # Request a data export.
             query_response = RestClient::Request.execute(
               :method => :post,
               :url => "#{@base_url}data_exports",
@@ -508,6 +505,7 @@ consumer_thread = Thread.new do
             output_results = "myoutputfile_#{searchID}.json"
             searchComplete = false
 
+            # Wait for data export to be complete.
             while searchComplete == false
             
               status_code = RestClient.get("#{@base_url}data_exports/status?search_id=#{searchID}", @headers).code
@@ -518,7 +516,7 @@ consumer_thread = Thread.new do
                 sleep(60)
                 next
               else
-                puts "ansyc query complete" if @debug
+                puts "async query (data export) complete" if @debug
                 searchComplete = true
                 File.open(output_results, 'w') {|f|
                   block = proc { |response|
@@ -526,8 +524,11 @@ consumer_thread = Thread.new do
                       f.write chunk
                     end
                   }
+                  # Retrieve data exports in a gzip file.
                   RestClient::Request.new(:method => :get, :url => "#{@base_url}data_exports?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
                 }
+
+                # Open gzip file and process.
                 gzfile = open(output_results)
                 gz = Zlib::GzipReader.new(gzfile)
                 vuln_ids = []
@@ -535,14 +536,13 @@ consumer_thread = Thread.new do
                 results_json.each do |item|
                   vuln_ids << item["id"]
                 end
-               
               end 
-                 
             end
+
             post_url = "#{@vuln_api_url}/#{@vuln_api_bulk}"
             puts "post_url = #{post_url}" if @debug
             
-
+            # Update vulnerabilities with "Bulk Vulnerabilities" API 5,000 vulnerabilities at a time.
             vuln_ids.each_slice(5000) do |a|
 
               json_data = json_data.insert(json_data.index('vulnerability')-1, "\"vulnerability_ids\": #{a},") 
@@ -553,8 +553,9 @@ consumer_thread = Thread.new do
 
               post_data(post_url,json_data)
 
-            
             end
+
+            # Delete gzip file.
             File.delete(output_results)
           end
 

--- a/Kenna-vuln-updater/vuln_updater.rb
+++ b/Kenna-vuln-updater/vuln_updater.rb
@@ -370,7 +370,7 @@ consumer_thread = Thread.new do
           Thread.exit
         rescue RestClient::BadRequest => e
           @output_filename.error("BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n")
-          puts "BadRequest: #{e.message}"
+          puts "BadRequest: #{e.message} for #{query_url}"
           Thread.exit
         rescue RestClient::Exception => e
           @retries ||= 0
@@ -565,7 +565,7 @@ consumer_thread = Thread.new do
           Thread.exit
         rescue RestClient::BadRequest => e
           @output_filename.error("BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n")
-          puts "BadRequest: #{e.message}"
+          puts "BadRequest: #{e.message} for #{query_url}"
           Thread.exit
         rescue RestClient::Exception => e
           @retries ||= 0

--- a/Kenna-vuln-updater/vuln_updater.rb
+++ b/Kenna-vuln-updater/vuln_updater.rb
@@ -22,9 +22,7 @@ require 'monitor'
 @vuln_status = ARGV[13] #vuln status all, open or other for retrieval 
 ARGV.length == 15 ? @base_url = ARGV[14] : @base_url = "https://api.kennasecurity.com/"
 
-@enc_colon = "%3A"
 @enc_dblquote = "%22"
-@enc_space = "%20"
 
 @start_time = Time.now
 @output_filename = Logger.new("kenna_vuln_updater_log-#{@start_time.strftime("%Y%m%dT%H%M")}.txt")

--- a/asset_inactivation_by_risk_meter/asset_inacivation-by-risk-meter.rb
+++ b/asset_inactivation_by_risk_meter/asset_inacivation-by-risk-meter.rb
@@ -15,21 +15,15 @@ require 'ipaddr'
 @asset_api_url = 'https://api.kennasecurity.com/assets'
 @asset_bulk_url = '/bulk'
 @search_url = "/search?" 
-@async_api_url = 'https://api.kennasecurity.com/assets/create_async_search'
 @headers = {'Content-Type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
-
-# Encoding characters
-@enc_colon = "%3A"
-@enc_dblquote = "%22"
-@enc_space = "%20"
 
 start_time = Time.now
 
 def find_json_status?(json)
   begin
-    json.fetch("status") == "incomplete"
-    return true
+    return json.fetch("status") == "incomplete"
   rescue Exception => e
+    puts("json.fetch(): #{e.message}")
     return false
   end
 end
@@ -49,31 +43,31 @@ def bulkUpdate(assets)
       :payload => holder,
       :headers => @headers
     )
-    rescue RestClient::UnprocessableEntity 
-      log_output = File.open(output_filename,'a+')
-      log_output << "UnprocessableEntity: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-      log_output.close
-      puts "UnprocessableEntity: #{e.message}"
+  rescue RestClient::UnprocessableEntity 
+    log_output = File.open(output_filename,'a+')
+    log_output << "UnprocessableEntity: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+    log_output.close
+    puts "UnprocessableEntity: #{e.message}"
 
-    rescue RestClient::BadRequest => e
+  rescue RestClient::BadRequest => e
+    log_output = File.open(output_filename,'a+')
+    log_output << "BadRequest: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.message}"
+  rescue RestClient::Exception => e
+    @retries ||= 0
+    if @retries < @max_retries
+      @retries += 1
+      sleep(15)
+      retry
+    else
       log_output = File.open(output_filename,'a+')
-      log_output << "BadRequest: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+      log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
       log_output.close
-      puts "BadRequest: #{e.message}"
-    rescue RestClient::Exception => e
-      @retries ||= 0
-      if @retries < @max_retries
-        @retries += 1
-        sleep(15)
-        retry
-      else
-        log_output = File.open(output_filename,'a+')
-        log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-        log_output.close
-        puts "Unable to get vulns: #{e.message}"
-      end
-    rescue Exception => e
-      puts "Exception: #{e.message}"
+      puts "Unable to get vulns: #{e.message}"
+    end
+  rescue Exception => e
+    puts "Exception: #{e.message}"
   end
   puts JSON.parse(query_post_return.body)
 end
@@ -107,62 +101,65 @@ producer_thread = Thread.new do
   CSV.foreach(@meta_file, :headers => true) do |row|
     rm_id = row["#{@rm_id_column}"]
 
+    # Search for assets in a risk meter by ID (rm_id).
     query_url = "#{@asset_api_url}#{@search_url}search_id=#{rm_id}"
 
-    async_query = false
     begin
       query_response = RestClient::Request.execute(
         :method => :get,
         :url => query_url,
         :headers => @headers
       )
-      rescue RestClient::TooManyRequests =>e
-                retry
-      rescue RestClient::UnprocessableEntity 
+    rescue RestClient::TooManyRequests => e
+      puts("TooManyRequests: #{e.message}")
+      retry
+    rescue RestClient::UnprocessableEntity 
+      log_output = File.open(output_filename,'a+')
+      log_output << "UnprocessableEntity: #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+      log_output.close
+      puts "BadRequest: #{query_url}"
+    rescue RestClient::BadRequest
+      log_output = File.open(output_filename,'a+')
+      log_output << "BadRequest: #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+      log_output.close
+      puts "BadRequest: #{query_url}"
+    rescue RestClient::Exception
+      @retries ||= 0
+      if @retries < @max_retries
+        @retries += 1
+        sleep(15)
+        retry
+      else
         log_output = File.open(output_filename,'a+')
-        log_output << "UnprocessableEntity: #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+        log_output << "General RestClient error #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
         log_output.close
-        puts "BadRequest: #{query_url}"
-      rescue RestClient::BadRequest
-        log_output = File.open(output_filename,'a+')
-        log_output << "BadRequest: #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{query_url}"
-      rescue RestClient::Exception
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          log_output = File.open(output_filename,'a+')
-          log_output << "General RestClient error #{query_url}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-          log_output.close
-          puts "Unable to get assets: #{query_url}"
-          next
-        end
+        puts "Unable to get assets: #{query_url}"
+        next
+      end
     end
     meta_response_json = JSON.parse(query_response.body)["meta"]
-    tot_vulns = meta_response_json.fetch("total_count")
-    next if tot_vulns == 0
+    tot_assets = meta_response_json.fetch("total_count")
+    next if tot_assets == 0
     pages = meta_response_json.fetch("pages")
     log_output = File.open(output_filename,'a+')
-    log_output << "Checking #{query_url}. Total assets = #{tot_vulns}\n"
+    log_output << "Checking #{query_url}. Total assets = #{tot_assets}\n"
     log_output.close
-    # Put the row on the work queue
+
+    asset_page_size = 500
     if pages > 20 then
-      async_query = true
+      # Calculate new page size and round up to the nearest 100.
+      asset_page_size = tot_assets / 20
+      page_size_in_hundreds = (asset_page_size / 100) + 1
+      asset_page_size = page_size_in_hundreds * 100
+      puts("Page size modified to #{asset_page_size}\n")
     end
 
     log_output = File.open(output_filename,'a+')
-    log_output << "Starting Thread for #{query_url} Total assets = #{tot_vulns}\n"
+    log_output << "Starting Thread for #{query_url} Total assets = #{tot_assets}\n"
     log_output.close
 
-    if async_query then
-      query_url = "#{@async_api_url}?search_id=#{rm_id}"
-    end
-
-    work_queue << Array[async_query,query_url]
+    # Put the row on the work queue
+    work_queue << Array[asset_page_size, query_url]
     
     # Tell the consumer to check the thread array so it can attempt to schedule the
     # next job if a free spot exists.
@@ -173,7 +170,6 @@ producer_thread = Thread.new do
   # Tell the consumer that we are finished downloading currencies
   sysexit = true
 end
-
 
 ## Iterate through CSV
 consumer_thread = Thread.new do
@@ -195,7 +191,7 @@ consumer_thread = Thread.new do
       # time a signal is sent to the "threads_available" variable
       threads_available.wait_while do
         threads.select { |thread| thread.nil? || thread.status == false  ||
-                                  thread["finished"].nil? == false}.length == 0
+                                  thread["finished"].nil? == false}.empty?
         if @debug then puts "in threads_available loop" end
       end
       # Once an available spot is found, get the index of that spot so we may
@@ -206,7 +202,7 @@ consumer_thread = Thread.new do
       if @debug then puts "i just found index = #{found_index}" end
     end
 
-    async_query = work_to_do[0]
+    asset_page_size = work_to_do[0]
     query_url = work_to_do[1]
     
     #json_data = JSON.parse(custom_field_string)
@@ -214,163 +210,80 @@ consumer_thread = Thread.new do
 
     threads[found_index] = Thread.new(work_to_do) do
       assets_array = []
+      query_url = "#{query_url}&per_page=#{asset_page_size}"
 
-      if !async_query then 
-        puts "starting regular query" if @debug
-        begin
+      puts "starting regular query" if @debug
+      begin
+        query_response = RestClient::Request.execute(
+          :method => :get,
+          :url => query_url,
+          :headers => @headers
+        )
+      
+        meta_response_json = JSON.parse(query_response.body)["meta"]
+        tot_assets = meta_response_json.fetch("total_count")
+        log_output = File.open(output_filename,'a+')
+        log_output << "Processing = #{query_url}. Total assets = #{tot_assets}\n"
+        log_output.close
+        if @debug then puts "Processing #{query_url} Total assets = #{tot_assets}" end
+        pages = meta_response_json.fetch("pages")
+
+        endloop = pages + 1
+        (1...endloop).step(1) do |i|
+          puts "Currently processing page #{i} of #{pages}"
+          #query_url = "#{query_url}&page=#{i}"
+          puts "paging url = #{query_url}&page=#{i}" if @debug
+
           query_response = RestClient::Request.execute(
             :method => :get,
-            :url => query_url,
+            :url => "#{query_url}&page=#{i}",
             :headers => @headers
           )
-        
-          meta_response_json = JSON.parse(query_response.body)["meta"]
-          tot_assets = meta_response_json.fetch("total_count")
-          log_output = File.open(output_filename,'a+')
-          log_output << "Processing = #{query_url}. Total assets = #{tot_assets}\n"
-          log_output.close
-          if @debug then puts "Processing #{query_url} Total assets = #{tot_assets}" end
-          pages = meta_response_json.fetch("pages")
-
-          endloop = pages + 1
-          (1...endloop).step(1) do |i|
-            puts "Currently processing page #{i} of #{pages}"
-            #query_url = "#{query_url}&page=#{i}"
-            puts "paging url = #{query_url}&page=#{i}" if @debug
-
-            query_response = RestClient::Request.execute(
-              :method => :get,
-              :url => "#{query_url}&page=#{i}",
-              :headers => @headers
-            )
-            # Build URL to set the custom field value for each vulnerability
-            #counter = 0
-            query_response_json = JSON.parse(query_response.body)["assets"]
-            query_response_json.each do |item|
-              asset_id = item["id"]
-              assets_array << asset_id
-              if assets_array.length == 30000 then
-                bulkUpdate(assets_array)
-                assets_array = []
-              end
-            end
-            bulkUpdate(assets_array)
-            Thread.current["finished"] = true
-            threads.synchronize do
-              threads_available.signal
+          # Build URL to set the custom field value for each vulnerability
+          #counter = 0
+          query_response_json = JSON.parse(query_response.body)["assets"]
+          query_response_json.each do |item|
+            asset_id = item["id"]
+            assets_array << asset_id
+            if assets_array.length == 30000 then
+              bulkUpdate(assets_array)
+              assets_array = []
             end
           end
-        rescue RestClient::TooManyRequests =>e
-          retry
-        rescue RestClient::UnprocessableEntity => e
-          log_output = File.open(output_filename,'a+')
-          log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::BadRequest => e
-          log_output = File.open(output_filename,'a+')
-          log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::Exception => e
-          @retries ||= 0
-          puts "one #{@retries}"
-          if @retries < @max_retries
-            @retries += 1
-            sleep(15)
-            retry
-          else
-            log_output = File.open(output_filename,'a+')
-            log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-            log_output.close
-            puts "Unable to get vulns: #{e.message}"
-            next
+          bulkUpdate(assets_array)
+          Thread.current["finished"] = true
+          threads.synchronize do
+            threads_available.signal
           end
         end
-      else
-        puts "starting async query" if @debug
-        begin
-          query_response = RestClient::Request.execute(
-            :method => :post,
-            :url => query_url,
-            :headers => @headers
-          ) 
-          query_response_json = JSON.parse(query_response.body)
-          searchID = query_response_json.fetch("search_id")
-          output_results = "myoutputfile_#{searchID}.json"
-          searchComplete = false
-
-          while searchComplete == false
-            puts "building the search"
-            File.open(output_results, 'w') {|f|
-              puts "file opened"
-                block = proc { |response|
-                  puts "in the block"
-                  response.read_body do |chunk| 
-                    f.write chunk
-                  end
-                }
-                RestClient::Request.new(:method => :get, :url => "https://api.kennasecurity.com/vulnerabilities/async_search?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
-            }
-
-            results_json = JSON.parse(File.read(output_results))
-
-            if find_json_status?(results_json) then 
-              #results_json.fetch("status") == "incomplete" then
-              puts "sleeping for async query" if @debug
-              sleep(60)
-              next
-            #end
-            else
-              puts "ansyc query complete" if @debug
-              searchComplete = true
-              results_json = JSON.parse(File.read(output_results))["assets"]
-              results_json.each do |item|
-                puts "processing vulns"
-                asset_id = item["id"]
-                assets_array << asset_id
-                if assets_array.length == 30000 then
-                  bulkUpdate(assets_array)
-                  assets_array = []
-                end
-              end
-              if assets_array.length == 30000 then
-                bulkUpdate(assets_array)
-                assets_array = []
-              end
-              Thread.current["finished"] = true
-              threads.synchronize do
-                threads_available.signal
-              end
-            end
-          end
-        rescue RestClient::TooManyRequests =>e
+      rescue RestClient::TooManyRequests =>e
+        retry
+      rescue RestClient::UnprocessableEntity => e
+        log_output = File.open(output_filename,'a+')
+        log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+        log_output.close
+        puts "BadRequest: #{e.message}"
+      rescue RestClient::BadRequest => e
+        log_output = File.open(output_filename,'a+')
+        log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+        log_output.close
+        puts "BadRequest: #{e.message}"
+      rescue RestClient::Exception => e
+        @retries ||= 0
+        puts "one #{@retries}"
+        if @retries < @max_retries
+          @retries += 1
+          sleep(15)
           retry
-        rescue RestClient::UnprocessableEntity => e
+        else
           log_output = File.open(output_filename,'a+')
-          log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
+          log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
           log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::BadRequest => e
-          log_output = File.open(output_filename,'a+')
-          log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::Exception => e
-          @retries ||= 0
-          if @retries < @max_retries
-            @retries += 1
-            sleep(15)
-            retry
-          else
-            log_output = File.open(output_filename,'a+')
-            log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
-            log_output.close
-            puts "Unable to get assets: #{e.message}"
-            next
-          end
+          puts "Unable to get vulns: #{e.message}"
+          next
         end
       end
+
       Thread.current["finished"] = true
       threads.synchronize do
         threads_available.signal
@@ -378,7 +291,6 @@ consumer_thread = Thread.new do
     end  
   end
 end
-
 
 # Join on both the producer and consumer threads so the main thread doesn't exit while
 # they are doing work.
@@ -390,6 +302,3 @@ threads.each do |thread|
     thread.join unless thread.nil?
 end
 puts "DONE!"
-
-
-

--- a/asset_inactivation_by_risk_meter/readme.md
+++ b/asset_inactivation_by_risk_meter/readme.md
@@ -10,8 +10,7 @@ This script uses a metadata CSV file that contains one or more risk meter IDs at
     
 ### Tested on:
 
-    ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin15]
-    
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
     
 ### Required Ruby classes/gems:
 

--- a/asset_inactivation_by_risk_meter/readme.md
+++ b/asset_inactivation_by_risk_meter/readme.md
@@ -1,19 +1,19 @@
 # Asset Inactivation By Risk Meter
 
-Set All Assets in a given Risk Meter set to inactive
+Set All Assets in a given Risk Meter set to inactive.
 
-This script will process a meta data file to set all assets in each listed risk meter to inactive
+This script uses a metadata CSV file that contains one or more risk meter IDs at a specified column.  Using the risk meter ID, the assets that are in the risk meter are inactived.
 
-Usage:
+## Usage:
 
     asset_inacivation-by-risk-meter.rb <Kenna API token> <risk meter meta data.csv> risk_meter_column
     
-Tested on:
+### Tested on:
 
     ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin15]
     
     
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
     rest-client
     json

--- a/asset_inactivation_by_risk_meter/readme.md
+++ b/asset_inactivation_by_risk_meter/readme.md
@@ -6,7 +6,7 @@ This script uses a metadata CSV file that contains one or more risk meter IDs at
 
 ## Usage:
 
-    asset_inacivation-by-risk-meter.rb <Kenna API token> <risk meter meta data.csv> risk_meter_column
+    asset_inacivation-by-risk-meter.rb <Kenna API token> <risk meter meta data.csv> <risk_meter_column>
     
 ### Tested on:
 

--- a/assets_in_risk_meters_check/assets_in_risk_meters_check.rb
+++ b/assets_in_risk_meters_check/assets_in_risk_meters_check.rb
@@ -16,13 +16,7 @@ require 'ipaddr'
 @asset_api_url = 'https://api.kennasecurity.com/assets'
 @asset_bulk_url = '/bulk'
 @search_url = "/search?" 
-@async_api_url = 'https://api.kennasecurity.com/assets/create_async_search'
 @headers = {'Content-Type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
-
-# Encoding characters
-@enc_colon = "%3A"
-@enc_dblquote = "%22"
-@enc_space = "%20"
 
 @start_time = Time.now
 
@@ -51,9 +45,9 @@ sysexit = false
 
 def find_json_status?(json)
   begin
-    json.fetch("status") == "incomplete"
-    return true
+    return json.fetch("status") == "incomplete"
   rescue Exception => e
+    puts("json.fetch(): #{e.message}")
     return false
   end
 end
@@ -74,31 +68,31 @@ def bulkUpdate(assets, tag_value)
       :payload => holder,
       :headers => @headers
     )
-    rescue RestClient::UnprocessableEntity => e
-      log_output = File.open(@output_filename,'a+')
-      log_output << "UnprocessableEntity: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-      log_output.close
-      puts "UnprocessableEntity: #{e.message}"
+  rescue RestClient::UnprocessableEntity => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "UnprocessableEntity: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "UnprocessableEntity: #{e.message}"
 
-    rescue RestClient::BadRequest => e
+  rescue RestClient::BadRequest => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "BadRequest: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.message}"
+  rescue RestClient::Exception => e
+    @retries ||= 0
+    if @retries < @max_retries
+      @retries += 1
+      sleep(15)
+      retry
+    else
       log_output = File.open(@output_filename,'a+')
-      log_output << "BadRequest: #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
       log_output.close
-      puts "BadRequest: #{e.message}"
-    rescue RestClient::Exception => e
-      @retries ||= 0
-      if @retries < @max_retries
-        @retries += 1
-        sleep(15)
-        retry
-      else
-        log_output = File.open(@output_filename,'a+')
-        log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "Unable to get vulns: #{e.message}"
-      end
-    rescue Exception => e
-      puts "Exception: #{e.message}"
+      puts "Unable to get vulns: #{e.message}"
+    end
+  rescue Exception => e
+    puts "Exception: #{e.message}"
   end
   puts JSON.parse(query_post_return.body)
 end
@@ -109,66 +103,71 @@ producer_thread = Thread.new do
   CSV.foreach(@meta_file, :headers => true) do |row|
     rm_id = row["#{@rm_id_column}"]
     tag_value = row["#{@tag_column}"]
-
     puts "got tag value #{tag_value}"
 
+    # Search for assets in a risk meter by ID (rm_id).
     query_url = "#{@asset_api_url}#{@search_url}search_id=#{rm_id}"
 
-    async_query = false
     begin
       query_response = RestClient::Request.execute(
         :method => :get,
         :url => query_url,
         :headers => @headers
       )
-      rescue RestClient::TooManyRequests =>e
-                retry
-      rescue RestClient::UnprocessableEntity 
+    rescue RestClient::TooManyRequests
+      log_output = File.open(@output_filename,'a+')
+      log_output << "TooManyRequests: #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output.close
+      retry
+    rescue RestClient::UnprocessableEntity 
+      log_output = File.open(@output_filename,'a+')
+      log_output << "UnprocessableEntity: #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output.close
+      puts "BadRequest: #{query_url}"
+    rescue RestClient::BadRequest
+      log_output = File.open(@output_filename,'a+')
+      log_output << "BadRequest: #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output.close
+      puts "BadRequest: #{query_url}"
+    rescue RestClient::Exception
+      @retries ||= 0
+      if @retries < @max_retries
+        @retries += 1
+        sleep(15)
+        retry
+      else
         log_output = File.open(@output_filename,'a+')
-        log_output << "UnprocessableEntity: #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+        log_output << "General RestClient error #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
         log_output.close
-        puts "BadRequest: #{query_url}"
-      rescue RestClient::BadRequest
-        log_output = File.open(@output_filename,'a+')
-        log_output << "BadRequest: #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{query_url}"
-      rescue RestClient::Exception
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          log_output = File.open(@output_filename,'a+')
-          log_output << "General RestClient error #{query_url}... (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "Unable to get assets: #{query_url}"
-          next
-        end
+        puts "Unable to get assets: #{query_url}"
+        next
+      end
     end
     puts query_response
+
     meta_response_json = JSON.parse(query_response.body)["meta"]
-    tot_vulns = meta_response_json.fetch("total_count")
-    next if tot_vulns == 0
+    tot_assets = meta_response_json.fetch("total_count")
+    next if tot_assets == 0
     pages = meta_response_json.fetch("pages")
     log_output = File.open(@output_filename,'a+')
-    log_output << "Checking #{query_url}. Total assets = #{tot_vulns}\n"
+    log_output << "Checking #{query_url}. Total assets = #{tot_assets}\n"
     log_output.close
-    # Put the row on the work queue
+
+    asset_page_size = 500
     if pages > 20 then
-      async_query = true
+      # Calculate new page size and round up to the nearest 100.
+      asset_page_size = tot_assets / 20
+      page_size_in_hundreds = (asset_page_size / 100) + 1
+      asset_page_size = page_size_in_hundreds * 100
+      puts("Page size modified to #{asset_page_size}\n")
     end
 
     log_output = File.open(@output_filename,'a+')
-    log_output << "Starting Thread for #{query_url} Total assets = #{tot_vulns}\n"
+    log_output << "Starting Thread for #{query_url} Total assets = #{tot_assets}\n"
     log_output.close
 
-    if async_query then
-      query_url = "#{@async_api_url}?search_id=#{rm_id}"
-    end
-
-    work_queue << Array[async_query,query_url,tag_value]
+    # Put the row on the work queue
+    work_queue << Array[asset_page_size, query_url, tag_value]
     
     # Tell the consumer to check the thread array so it can attempt to schedule the
     # next job if a free spot exists.
@@ -179,7 +178,6 @@ producer_thread = Thread.new do
   # Tell the consumer that we are finished downloading currencies
   sysexit = true
 end
-
 
 ## Iterate through CSV
 consumer_thread = Thread.new do
@@ -201,7 +199,7 @@ consumer_thread = Thread.new do
       # time a signal is sent to the "threads_available" variable
       threads_available.wait_while do
         threads.select { |thread| thread.nil? || thread.status == false  ||
-                                  thread["finished"].nil? == false}.length == 0
+                                  thread["finished"].nil? == false}.empty?
         if @debug then puts "in threads_available loop" end
       end
       # Once an available spot is found, get the index of that spot so we may
@@ -212,7 +210,7 @@ consumer_thread = Thread.new do
       if @debug then puts "i just found index = #{found_index}" end
     end
 
-    async_query = work_to_do[0]
+    asset_page_size = work_to_do[0]
     query_url = work_to_do[1]
     tag_value = work_to_do[2]
 
@@ -224,162 +222,80 @@ consumer_thread = Thread.new do
     threads[found_index] = Thread.new(work_to_do) do
       assets_array = []
 
-      if !async_query then 
-        puts "starting regular query" if @debug
-        begin
+      puts "starting regular query" if @debug
+      query_url = "#{query_url}&per_page=#{asset_page_size}"
+
+      begin
+        query_response = RestClient::Request.execute(
+          :method => :get,
+          :url => query_url,
+          :headers => @headers
+        )
+      
+        meta_response_json = JSON.parse(query_response.body)["meta"]
+        tot_assets = meta_response_json.fetch("total_count")
+        log_output = File.open(@output_filename,'a+')
+        log_output << "Processing = #{query_url}. Total assets = #{tot_assets}\n"
+        log_output.close
+        if @debug then puts "Processing #{query_url} Total assets = #{tot_assets}" end
+        pages = meta_response_json.fetch("pages")
+ 
+        endloop = pages + 1
+        (1...endloop).step(1) do |i|
+          puts "Currently processing page #{i} of #{pages}"
+          #query_url = "#{query_url}&page=#{i}"
+          puts "paging url = #{query_url}&page=#{i}" if @debug
+ 
           query_response = RestClient::Request.execute(
             :method => :get,
-            :url => query_url,
+            :url => "#{query_url}&page=#{i}",
             :headers => @headers
           )
-        
-          meta_response_json = JSON.parse(query_response.body)["meta"]
-          tot_assets = meta_response_json.fetch("total_count")
-          log_output = File.open(@output_filename,'a+')
-          log_output << "Processing = #{query_url}. Total assets = #{tot_assets}\n"
-          log_output.close
-          if @debug then puts "Processing #{query_url} Total assets = #{tot_assets}" end
-          pages = meta_response_json.fetch("pages")
-
-          endloop = pages + 1
-          (1...endloop).step(1) do |i|
-            puts "Currently processing page #{i} of #{pages}"
-            #query_url = "#{query_url}&page=#{i}"
-            puts "paging url = #{query_url}&page=#{i}" if @debug
-
-            query_response = RestClient::Request.execute(
-              :method => :get,
-              :url => "#{query_url}&page=#{i}",
-              :headers => @headers
-            )
-            # Build URL to set the custom field value for each vulnerability
-            #counter = 0
-            query_response_json = JSON.parse(query_response.body)["assets"]
-            query_response_json.each do |item|
-              asset_id = item["id"]
-              assets_array << asset_id
-              if assets_array.length == 30000 then
-                bulkUpdate(assets_array,tag_value)
-                assets_array = []
-              end
-            end
-            bulkUpdate(assets_array,tag_value)
-            Thread.current["finished"] = true
-            threads.synchronize do
-              threads_available.signal
+          # Build URL to set the custom field value for each vulnerability
+          #counter = 0
+          query_response_json = JSON.parse(query_response.body)["assets"]
+          query_response_json.each do |item|
+            asset_id = item["id"]
+            assets_array << asset_id
+            if assets_array.length == 30000 then
+              bulkUpdate(assets_array,tag_value)
+              assets_array = []
             end
           end
-        rescue RestClient::TooManyRequests =>e
-          retry
-        rescue RestClient::UnprocessableEntity => e
-          log_output = File.open(@output_filename,'a+')
-          log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::BadRequest => e
-          log_output = File.open(@output_filename,'a+')
-          log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::Exception => e
-          @retries ||= 0
-          puts "one #{@retries}"
-          if @retries < @max_retries
-            @retries += 1
-            sleep(15)
-            retry
-          else
-            log_output = File.open(@output_filename,'a+')
-            log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-            log_output.close
-            puts "Unable to get vulns: #{e.message}"
-            next
+          bulkUpdate(assets_array,tag_value)
+          Thread.current["finished"] = true
+          threads.synchronize do
+            threads_available.signal
           end
         end
-      else
-        puts "starting async query" if @debug
-        begin
-          query_response = RestClient::Request.execute(
-            :method => :post,
-            :url => query_url,
-            :headers => @headers
-          ) 
-          query_response_json = JSON.parse(query_response.body)
-          searchID = query_response_json.fetch("search_id")
-          output_results = "myoutputfile_#{searchID}.json"
-          searchComplete = false
-
-          while searchComplete == false
-            puts "building the search"
-            File.open(output_results, 'w') {|f|
-              puts "file opened"
-                block = proc { |response|
-                  puts "in the block"
-                  response.read_body do |chunk| 
-                    f.write chunk
-                  end
-                }
-                RestClient::Request.new(:method => :get, :url => "https://api.kennasecurity.com/vulnerabilities/async_search?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
-            }
-
-            results_json = JSON.parse(File.read(output_results))
-
-            if find_json_status?(results_json) then 
-              #results_json.fetch("status") == "incomplete" then
-              puts "sleeping for async query" if @debug
-              sleep(60)
-              next
-            #end
-            else
-              puts "ansyc query complete" if @debug
-              searchComplete = true
-              results_json = JSON.parse(File.read(output_results))["assets"]
-              results_json.each do |item|
-                puts "processing vulns"
-                asset_id = item["id"]
-                assets_array << asset_id
-                if assets_array.length == 30000 then
-                  bulkUpdate(assets_array,tag_value)
-                  assets_array = []
-                end
-              end
-              if assets_array.length == 30000 then
-                bulkUpdate(assets_array,tag_value)
-                assets_array = []
-              end
-              Thread.current["finished"] = true
-              threads.synchronize do
-                threads_available.signal
-              end
-            end
-          end
-        rescue RestClient::TooManyRequests =>e
+      rescue RestClient::TooManyRequests =>e
+        retry
+      rescue RestClient::UnprocessableEntity => e
+        log_output = File.open(@output_filename,'a+')
+        log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+        log_output.close
+        puts "BadRequest: #{e.message}"
+      rescue RestClient::BadRequest => e
+        log_output = File.open(@output_filename,'a+')
+        log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+        log_output.close
+        puts "BadRequest: #{e.message}"
+      rescue RestClient::Exception => e
+        @retries ||= 0
+        puts "one #{@retries}"
+        if @retries < @max_retries
+          @retries += 1
+          sleep(15)
           retry
-        rescue RestClient::UnprocessableEntity => e
+        else
           log_output = File.open(@output_filename,'a+')
-          log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+          log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
           log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::BadRequest => e
-          log_output = File.open(@output_filename,'a+')
-          log_output << "BadRequest: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "BadRequest: #{e.message}"
-        rescue RestClient::Exception => e
-          @retries ||= 0
-          if @retries < @max_retries
-            @retries += 1
-            sleep(15)
-            retry
-          else
-            log_output = File.open(@output_filename,'a+')
-            log_output << "General RestClient error #{query_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-            log_output.close
-            puts "Unable to get assets: #{e.message}"
-            next
-          end
+          puts "Unable to get vulns: #{e.message}"
+          next
         end
       end
+
       Thread.current["finished"] = true
       threads.synchronize do
         threads_available.signal
@@ -399,6 +315,3 @@ threads.each do |thread|
     thread.join unless thread.nil?
 end
 puts "DONE!"
-
-
-

--- a/assets_in_risk_meters_check/readme.md
+++ b/assets_in_risk_meters_check/readme.md
@@ -6,13 +6,11 @@ This script will process a metadata CSV file to create tags for all assets in re
 
 ## Usage:
 
-    assets_in_risk_meters_check.rb <Kenna API token> <risk meter meta data.csv> risk_meter_column tagname_column
-    
+    assets_in_risk_meters_check.rb <Kenna API token> <risk meter meta data.csv> <risk_meter_column> <tagname_column>
     
 ### Tested on:
 
-    ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin15]
-    
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
     
 ### Required Ruby classes/gems:
 

--- a/assets_in_risk_meters_check/readme.md
+++ b/assets_in_risk_meters_check/readme.md
@@ -1,20 +1,20 @@
 # Assets in risk meter check
 
-Generate a tag for all assets in a risk meter
+Generate a tag for all assets in a risk meter.
 
-This script will process a meta data file to create tags for all assets in requested risk meters. From the UI search can then be done to find all asset NOT in a risk meter. It is recommended that the same prefix be used for all tags. Example: RM:1, RM:2, RM:3. This will allow for easier removal of tags and easiers searching in the UI. If tag\_reset feature is turned on for the connector, they tags will be automatically cleared for all active assets. If not the Tag Remover script can be run to remove the tag from all assets.  
+This script will process a metadata CSV file to create tags for all assets in requested risk meters. From the UI, a search can then be done to find all asset NOT in a risk meter. It is recommended that the same prefix be used for all tags. Example: RM:1, RM:2, RM:3. This will allow for easier removal of tags and easiers searching in the UI. If tag\_reset feature is turned on for the connector, they tags will be automatically cleared for all active assets. If not the Tag Remover script can be run to remove the tag from all assets.  
 
-Usage:
+## Usage:
 
     assets_in_risk_meters_check.rb <Kenna API token> <risk meter meta data.csv> risk_meter_column tagname_column
     
     
-Tested on:
+### Tested on:
 
     ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin15]
     
     
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
     rest-client
     json

--- a/assets_in_risk_meters_check/risk_meters_meta.csv
+++ b/assets_in_risk_meters_check/risk_meters_meta.csv
@@ -1,4 +1,2 @@
 rmid,tag_value
-9036,RM:Risky
-51188,RM:Atlas
-65697,RM:SCA CUL DEV
+235481,railroad:BNSF

--- a/clear_due_dates/README.md
+++ b/clear_due_dates/README.md
@@ -1,23 +1,24 @@
 # Clear Due Dates
 
-These Scripts will clear out all due dates from an instance:
+These scripts will clear out all due dates from an instance:
 
-clear due date = uses data extract to retrieve all vulns - good for smaller data sets
-clear due date via assets = uses list of assets to portion out updates into batches for better performance on larger files
+`clear_due_date.rb`: uses data exports to retrieve all vulnerabilities - good for smaller data sets
+`clear_due_date_via_assets.rb`: uses list of assets to portion out updates into batches for better performance on larger files
 
 Data export APIs are used to obtain the data.
 
 ## Usage:
 
-clear_due_date.rb KennaAPItoken
-clear_due_date_via_assets.rb KennaAPItoken number-of-assets
+    clear_due_date.rb <KennaAPItoken>
+    clear_due_date_via_assets.rb <KennaAPItoken> <number-of-assets>
 
 number of assets: int number of assets to be pulled in each group. Number should be low enough to that vuln pull is less than 20 pages. Error will be thrown if vuln pull exceeds 20 pages. Expected range 15-30 assets. 
 
 ### Tested on:
 
-ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
 
 ### Required Ruby classes/gems:
 
-rest-client
+    rest-client
+    json

--- a/clear_due_dates/README.md
+++ b/clear_due_dates/README.md
@@ -2,8 +2,8 @@
 
 These scripts will clear out all due dates from an instance:
 
-`clear_due_date.rb`: uses data exports to retrieve all vulnerabilities - good for smaller data sets
-`clear_due_date_via_assets.rb`: uses list of assets to portion out updates into batches for better performance on larger files
+* `clear_due_date.rb`: uses data exports to retrieve all vulnerabilities - good for smaller data sets
+* `clear_due_date_via_assets.rb`: uses list of assets to portion out updates into batches for better performance on larger files
 
 Data export APIs are used to obtain the data.
 

--- a/clear_due_dates/README.md
+++ b/clear_due_dates/README.md
@@ -1,22 +1,23 @@
-# clear due dates
+# Clear Due Dates
 
-These Scripts will clear out all due dates from an instance
+These Scripts will clear out all due dates from an instance:
 
 clear due date = uses data extract to retrieve all vulns - good for smaller data sets
 clear due date via assets = uses list of assets to portion out updates into batches for better performance on larger files
 
-Usage:
+Data export APIs are used to obtain the data.
+
+## Usage:
 
 clear_due_date.rb KennaAPItoken
-clear_due_date_via_assets.rb KennaAPItoken numberofassets
+clear_due_date_via_assets.rb KennaAPItoken number-of-assets
 
 number of assets: int number of assets to be pulled in each group. Number should be low enough to that vuln pull is less than 20 pages. Error will be thrown if vuln pull exceeds 20 pages. Expected range 15-30 assets. 
 
-
-Tested on:
+### Tested on:
 
 ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]
 
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
 rest-client

--- a/clear_due_dates/clear_due_date_via_assets.rb
+++ b/clear_due_dates/clear_due_date_via_assets.rb
@@ -8,11 +8,10 @@ require 'json'
 ARGV.length == 3 ? @add_query = ARGV[2] : @add_query = nil #unencoded query string to add to search
 ARGV.length == 4 ? @base_url = ARGV[3] : @base_url = "https://api.kennasecurity.com/" #set only for KPD or EU
 
-
 #Variables we'll need later
 @post_url = "#{@base_url}vulnerabilities/bulk"
 @vuln_url = "#{@base_url}vulnerabilities/search"
-@bulk_url = "#{@base_url}data_exports"
+@data_export_url = "#{@base_url}data_exports"
 
 @headers = {'Content-type' => 'application/json', 'X-Risk-Token' => @token }
 
@@ -21,12 +20,6 @@ ARGV.length == 4 ? @base_url = ARGV[3] : @base_url = "https://api.kennasecurity.
 start_time = Time.now
 @output_filename = Logger.new("clear_due_date-#{start_time.strftime("%Y%m%dT%H%M")}.txt")
 @debug = false
-
-
-# Encoding characters
-enc_colon = "%3A"
-enc_dblquote = "%22"
-enc_space = "%20"
 
 def bulkUpdate(vulnids)
   puts "starting bulk update" if @debug
@@ -66,45 +59,46 @@ def bulkUpdate(vulnids)
     @output_filename.error("Unable to get vulns - general exception: #{e.backtrace.inspect}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})")
     puts "Unable to get vulns: #{e.message} #{e.backtrace.inspect}"
   end
+
+  @output_filename.error("bulk vuln update status: #{JSON.parse(query_post_return.body)}... time: #{Time.now.to_s}\n")
 end
 
 def get_data(get_url)
   puts "starting query" if @debug
   puts "get data url = #{get_url}" if @debug
   query_return = ""
-   begin
-      query_return = RestClient::Request.execute(
-        :method => :get,
-        :url => get_url,
-        :headers => @headers
-      )
-      rescue RestClient::TooManyRequests =>e
+    begin
+    query_return = RestClient::Request.execute(
+      :method => :get,
+      :url => get_url,
+      :headers => @headers
+    )
+    rescue RestClient::TooManyRequests =>e
+      retry
+    rescue RestClient::UnprocessableEntity => e
+      puts "unprocessible entity: #{e.message}"
+    rescue RestClient::BadRequest => e
+      @output_filename.error("BadRequest: #{@post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+      puts "BadRequest: #{e.backtrace.inspect}"
+    rescue RestClient::Exception => e
+      @retries ||= 0
+      if @retries < @max_retries
+        @retries += 1
+        sleep(15)
         retry
-      rescue RestClient::UnprocessableEntity => e
-        puts "unprocessible entity: #{e.message}"
-      rescue RestClient::BadRequest => e
-        @output_filename.error("BadRequest: #{@post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-        puts "BadRequest: #{e.backtrace.inspect}"
-      rescue RestClient::Exception => e
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          @output_filename.error("General RestClient error #{@post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-          puts "Unable to get vulns: #{e.backtrace.inspect}"
-        end
-      rescue Exception => e
-        @output_filename.error("BadRequest: #{@post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-        puts "BadRequest: #{e.backtrace.inspect}"
+      else
+        @output_filename.error("General RestClient error #{@post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+        puts "Unable to get vulns: #{e.backtrace.inspect}"
+      end
+    rescue Exception => e
+      @output_filename.error("BadRequest: #{@post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+      puts "BadRequest: #{e.backtrace.inspect}"
     end
   return query_return
 end
 
 def get_bulk_assets()
   puts "starting bulk query" if @debug
-  query_return = ""
   q = "_exists_:due_date"
   q = "#{q} AND #{@add_query}" unless @add_query.nil? || @add_query.empty?
   bulk_query_json_string = "{\"status\": [\"active\"],"
@@ -118,7 +112,7 @@ def get_bulk_assets()
   begin
     query_response = RestClient::Request.execute(
       :method => :post,
-      :url => @bulk_url,
+      :url => @data_export_url,
       :headers => @headers,
       :payload => bulk_query_json
     ) 
@@ -132,24 +126,28 @@ def get_bulk_assets()
 
     while searchComplete == false
       
-      status_code = RestClient.get("#{@bulk_url}/status?search_id=#{searchID}", @headers).code
+      status_code = RestClient.get("#{@data_export_url}/status?search_id=#{searchID}", @headers).code
 
       puts "status code =#{status_code}" if @debug
       if status_code != 200 then 
-        puts "sleeping for async query" if @debug
+        puts "sleeping for async query (data export)" if @debug
         sleep(60)
         next
       else
-        puts "ansyc query complete" if @debug
+        puts "ansyc query complete (data export)" if @debug
         searchComplete = true
+
+        # Download the gzip file.
         File.open(output_results, 'w') {|f|
           block = proc { |response|
             response.read_body do |chunk| 
               f.write chunk
             end
           }
-          RestClient::Request.new(:method => :get, :url => "#{@bulk_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
+          RestClient::Request.new(:method => :get, :url => "#{@data_export_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
         }
+        
+        # Open the gzip file and process.
         gzfile = open(output_results)
         gz = Zlib::GzipReader.new(gzfile)
         json_data = JSON.parse(gz.read)["assets"]

--- a/clear_due_dates/clear_due_date_via_assets.rb
+++ b/clear_due_dates/clear_due_date_via_assets.rb
@@ -22,7 +22,8 @@ start_time = Time.now
 @debug = false
 
 def bulkUpdate(vulnids)
-  puts "starting bulk update" if @debug
+  puts "Updating #{vulnids.length()} vulnerabilities"
+
   json_string = nil
   json_string = "{\"vulnerability_ids\": #{vulnids}, "
   json_string = "#{json_string}\"vulnerability\": {"
@@ -97,6 +98,7 @@ def get_data(get_url)
   return query_return
 end
 
+# get_bulk_assets() uses data exports APIs.
 def get_bulk_assets()
   puts "starting bulk query" if @debug
   q = "_exists_:due_date"
@@ -174,9 +176,12 @@ def get_bulk_assets()
     @output_filename.error("General Exception:...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
     puts "BadRequest: #{e.backtrace.inspect}"
   end
+
   File.delete output_results
   return json_data
 end
+
+# main
 asset_array = []
 asset_json = get_bulk_assets
 if !asset_json.nil? then
@@ -211,7 +216,7 @@ if !asset_json.nil? then
 
         vuln_page += 1
       end
-      vuln_array.each_slice(7000) do |b|
+      vuln_array.each_slice(5000) do |b|
         bulkUpdate(b)
       end 
     end

--- a/vulnerability_reporting/README.md
+++ b/vulnerability_reporting/README.md
@@ -1,8 +1,8 @@
 # Vulnerability CSV reports
 
-Scripts product CSV reports
+Scripts produce CSV reports
 
-vuln_reporting.rb produces csv reports and optionally send them via email 
+vuln_reporting.rb produces CSV reports and optionally send them via email 
 
 Meta File should have 3 columns
 
@@ -22,9 +22,7 @@ rest-client
 json
 mail
 
-
 __________________________________________________________________________________________________________________
-
 
 csv_extract_with_details.rb will produce a report of all vulnerabilities in Kenna including details. 
 
@@ -46,4 +44,3 @@ Required Ruby classes/gems:
 
 rest-client
 json
-

--- a/vulnerability_reporting/README.md
+++ b/vulnerability_reporting/README.md
@@ -1,9 +1,11 @@
 # Vulnerability CSV reports
 
-Scripts produce CSV reports
+Scripts that produce CSV reports.
 
-vuln_reporting.rb produces CSV reports and optionally send them via email 
+`vuln_reporting.rb` produces CSV reports and optionally send them via email 
+`csv_extract_with_details.rb` produces a report of all vulnerabilities in Kenna including details. 
 
+## vuln_reporting.rb Usage
 Meta File should have 3 columns
 
 query
@@ -12,35 +14,34 @@ email_recipients
 
 Script will process a report for each line in the meta file and optionally email it to the listed recipient(s)
 
-vuln_reporting.rb Kenna_API_token instruction_meta_file.csv include_solution? send_mail? opt_mail_server opt_port opt_username opt_password opt_from_address
+    vuln_reporting.rb <Kenna_API_token> <instruction_meta_file.csv> <include_solution?> <send_mail?> [opt_mail_server] [opt_port] [opt_username] [opt_password] [opt_from_address]
 
 If send_mail = true then opt params are required. 
 
-Required Ruby classes/gems:
+### Tested on
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
 
-rest-client
-json
-mail
+### Required Ruby classes/gems
+    rest-client
+    csv
+    json
+    mail
 
-__________________________________________________________________________________________________________________
+## csv_extract_with_details.rb Usage
+The script pages through all assets and then uses groups of assets IDs to pull down vulnerabilities in chunks small enough to include details. 
 
-csv_extract_with_details.rb will produce a report of all vulnerabilities in Kenna including details. 
+    csv_extract_with_details.rb <Kenna_API_token> <assetsPerQuery> <OutputReportName> <IncludeDetails> [optRiskMeterID] [optQParam] [optBase_url]
 
-The script pages through all assets and then uses groups of assets ids to pull down vulnerabilities in chunks small enough to include details. 
-
-csv_extract_with_details.rb Kenna_API_token assetsPerQuery OutputReportName IncludeDetails optRiskMeterID optQParam optBase_url
-
-- assetsPerQuery - should be adjusted so that the vulns pulled back does not exceed 20 pages. Script with throw and error if 20 pages are exceeded.
+- assetsPerQuery - should be adjusted so that the vulns pulled back does not exceed 20 pages. Script with throw and error if 20 pages are exceeded, or if too many assets per query is specified.
 - OutputReportName - CSV file that will hold the results.
 - IncludeDetails - true or false (note you must have platform permissions for your Kenna Instance to export details)
 - optRiskMeterID - if risk meter (asset group) id is provided, only assets/vulns from that risk meter will be returned in the query. If left null, all active assets will be used for the vuln query.
 - optQParam - used in conjunction with the risk meter option if the risk meter has additional params that need to be processed. optRiskMeterID is used for the bulk query against the assets table but when retrieving the individual vulns a query string will be needed. Example RM query tag:(1 2 3) & vulnerability_score:>69. Risk meter id will get the correct assets returned for tag:(1 2 3) but if you don't pass "vulnerability_score:>69 in the optQParam then you will get all vulns on the assets instead of just those with score over 69. 
 - optBase_url - defaults to US API url, but should be set for EU or private deployments
 
-Tested on:
-ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]
+### Tested on
+    ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
 
-Required Ruby classes/gems:
-
+### Required Ruby classes/gems
 rest-client
 json

--- a/vulnerability_reporting/csv_extract_with_details.rb
+++ b/vulnerability_reporting/csv_extract_with_details.rb
@@ -54,8 +54,7 @@ csv_headers =
 csv_headers << "details" if @include_details
 
 def get_data(get_url)
-  puts "starting query" if @debug
-  puts "get data url = #{get_url}" if @debug
+  puts "get data URL: #{get_url}" if @debug
   query_return = ""
   begin
     query_return = RestClient::Request.execute(
@@ -162,19 +161,21 @@ def get_bulk_assets()
   return json_data
 end
 
-
+# main
 CSV.open(@report_filename , 'w') do |csv|
   csv << csv_headers
   csv.close
 end
 asset_array = []
 
+puts "Obtaining assets. This could take some time."
 asset_json = get_bulk_assets()
 if !asset_json.nil? then
   asset_json.each do |asset| 
     asset_array << Array[asset.fetch("id"),asset.fetch("hostname"),asset.fetch("ip_address"),asset.fetch("operating_system"),asset.fetch("tags").join(',')]
   end
 end
+puts "Processing assets."
 
 asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
   id_array =[]
@@ -188,6 +189,8 @@ asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
   vuln_query = "#{vuln_query}&include_details=true" if @include_details
   vuln_pages = 0
   vuln_page = 1
+
+  puts "Processinng vulnerabiities per assets.  This could take some time."
   CSV.open(@report_filename , 'a') do |csv|
     #csv << csv_headers
     vuln_json = JSON.parse(get_data(vuln_query))
@@ -287,6 +290,3 @@ asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
     end
   end
 end
-
-
-

--- a/vulnerability_reporting/csv_extract_with_details.rb
+++ b/vulnerability_reporting/csv_extract_with_details.rb
@@ -15,7 +15,7 @@ ARGV.length > 6 ? @base_url = ARGV[6] : @base_url = "https://api.kennasecurity.c
 #Variables we'll need later
 @vuln_url = "#{@base_url}vulnerabilities/search?per_page=5000"
 @rm_url = "#{@base_url}asset_groups/"
-@bulk_url = "#{@base_url}data_exports"
+@data_exports_url = "#{@base_url}data_exports"
 @headers = {'Content-type' => 'application/json', 'X-Risk-Token' => @token }
 
 @max_retries = 5
@@ -26,9 +26,6 @@ start_time = Time.now
 
 
 # Encoding characters
-enc_colon = "%3A"
-enc_dblquote = "%22"
-enc_space = "%20"
 csv_headers = 
   [
     "id",
@@ -53,45 +50,45 @@ csv_headers =
     "os",
     "tags"
   ]
-csv_headers <<"details" if @include_details
+
+csv_headers << "details" if @include_details
 
 def get_data(get_url)
   puts "starting query" if @debug
   puts "get data url = #{get_url}" if @debug
   query_return = ""
-   begin
-      query_return = RestClient::Request.execute(
-        :method => :get,
-        :url => get_url,
-        :headers => @headers
-      )
-      rescue RestClient::TooManyRequests =>e
-        retry
-      rescue RestClient::UnprocessableEntity => e
-        puts "unprocessible entity: #{e.message}"
-      rescue RestClient::BadRequest => e
-        @output_filename.error("Rest client BadRequest: #{get_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-        puts "BadRequest: #{e.backtrace.inspect}"
-      rescue RestClient::Exception => e
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          @output_filename.error("General RestClient error #{get_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-          puts "Unable to get vulns: #{e.backtrace.inspect}"
-        end
-      rescue Exception => e
-        @output_filename.error("General Exception: #{get_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
-        puts "BadRequest: #{e.backtrace.inspect}"
+  begin
+    query_return = RestClient::Request.execute(
+      :method => :get,
+      :url => get_url,
+      :headers => @headers
+    )
+  rescue RestClient::TooManyRequests =>e
+   retry
+  rescue RestClient::UnprocessableEntity => e
+    puts "unprocessible entity: #{e.message}"
+  rescue RestClient::BadRequest => e
+    @output_filename.error("Rest client BadRequest: #{get_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+    puts "BadRequest: #{e.backtrace.inspect}"
+  rescue RestClient::Exception => e
+    @retries ||= 0
+    if @retries < @max_retries
+      @retries += 1
+      sleep(15)
+      retry
+    else
+      @output_filename.error("General RestClient error #{get_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+      puts "Unable to get vulns: #{e.backtrace.inspect}"
     end
+  rescue Exception => e
+    @output_filename.error("General Exception: #{get_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
+    puts "BadRequest: #{e.backtrace.inspect}"
+  end
   return query_return
 end
 
 def get_bulk_assets()
   puts "starting bulk query" if @debug
-  query_return = ""
   bulk_query_json_string = "{\"status\": [\"active\"],"
   bulk_query_json_string = bulk_query_json_string + " \"search_id\": \"#{@risk_meter_id}\"," if !@risk_meter_id.nil? && !@risk_meter_id.empty?
   bulk_query_json_string = bulk_query_json_string + " \"export_settings\": { \"format\": \"json\", "
@@ -103,7 +100,7 @@ def get_bulk_assets()
   begin
     query_response = RestClient::Request.execute(
       :method => :post,
-      :url => @bulk_url,
+      :url => @data_exports_url,
       :headers => @headers,
       :payload => bulk_query_json
     ) 
@@ -117,7 +114,7 @@ def get_bulk_assets()
 
     while searchComplete == false
       
-      status_code = RestClient.get("#{@bulk_url}/status?search_id=#{searchID}", @headers).code
+      status_code = RestClient.get("#{@data_exports_url}/status?search_id=#{searchID}", @headers).code
 
       puts "status code =#{status_code}" if @debug
       if status_code != 200 then 
@@ -133,7 +130,7 @@ def get_bulk_assets()
               f.write chunk
             end
           }
-          RestClient::Request.new(:method => :get, :url => "#{@bulk_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
+          RestClient::Request.new(:method => :get, :url => "#{@data_exports_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
         }
         gzfile = open(output_results)
         gz = Zlib::GzipReader.new(gzfile)
@@ -200,7 +197,7 @@ asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
         puts "TOO MANY VULNS RERUN WITH A LOWER ASSET COUNT PER BLOCK"
         abort
       end
-      vuln_array = []
+
       while vuln_page <= vuln_pages+1 do 
         puts "vuln pages = #{vuln_pages} and vuln page = #{vuln_page}" if @debug
         vuln_json = JSON.parse(get_data("#{vuln_query}&page=#{vuln_page}"))
@@ -211,7 +208,6 @@ asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
           cve_id = nil
           score = nil
           cve_description = nil
-          cve_published = nil
           created = nil
           last_seen = nil
           qids = []
@@ -259,7 +255,7 @@ asset_array.each_slice(@assets_per_query.to_i) do |all_assets|
           os = a[3]
           tags = a[4]
           details = vuln["scanner_vulnerabilities"].first.fetch("details") unless vuln["scanner_vulnerabilities"].first.nil? || !@include_details
-          cvs_row = []
+          csv_row = []
 
           csv_row = [vuln_id,
             status,

--- a/vulnerability_reporting/vuln_reporting.rb
+++ b/vulnerability_reporting/vuln_reporting.rb
@@ -17,9 +17,7 @@ require 'mail'
 
 #Variables we'll need later
 @base_url = 'https://api.kennasecurity.com/'
-#@ag_url = "#{base_url}asset_groups"
-#@fixes_url = "#{base_url}fixes"
-@bulk_url = "#{@base_url}data_exports"
+@data_exports_url = "#{@base_url}data_exports"
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token }
 start_time = Time.now
 @output_filename = Logger.new("csv-extract-#{start_time.strftime("%Y%m%dT%H%M")}.txt")
@@ -85,7 +83,7 @@ end
 ## Iterate through CSV
 CSV.foreach(@csv_file, :headers => true){|row|
 
-  current_line = $.
+  #current_line = $.
   query = nil
   email_recipients = nil
 
@@ -105,7 +103,7 @@ CSV.foreach(@csv_file, :headers => true){|row|
   begin
     query_response = RestClient::Request.execute(
       :method => :post,
-      :url => @bulk_url,
+      :url => @data_exports_url,
       :headers => @headers,
       :payload => bulk_query_json
     ) 
@@ -120,24 +118,28 @@ CSV.foreach(@csv_file, :headers => true){|row|
 
     while searchComplete == false
       
-      status_code = RestClient.get("#{@bulk_url}/status?search_id=#{searchID}", @headers).code
+      status_code = RestClient.get("#{@data_exports_url}/status?search_id=#{searchID}", @headers).code
 
       puts "status code =#{status_code}" if @debug
       if status_code != 200 then 
-        puts "sleeping for async query" if @debug
+        puts "sleeping for async query (data_exports)" if @debug
         sleep(60)
         next
       else
-        puts "ansyc query complete" if @debug
+        puts "ansyc query complete (data_exports)" if @debug
         searchComplete = true
+        
+        # Download the gzip file.
         File.open(output_results, 'w') {|f|
           block = proc { |response|
             response.read_body do |chunk| 
               f.write chunk
             end
           }
-          RestClient::Request.new(:method => :get, :url => "#{@bulk_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
+          RestClient::Request.new(:method => :get, :url => "#{@data_exports_url}?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
         }
+        
+        # Open the gzip file and process.
         gzfile = open(output_results)
         gz = Zlib::GzipReader.new(gzfile)
         json_data = JSON.parse(gz.read)["vulnerabilities"]
@@ -150,9 +152,9 @@ CSV.foreach(@csv_file, :headers => true){|row|
 
       csv << csv_headers
 
+      # Go through each vulnerability.  First initializing all fields to nill, and
+      # setting the fields to values if available.
       json_data.each do |vuln|
-
-
         risk_score = nil
         cvss_severity = nil
         cvss_threat = nil
@@ -185,8 +187,6 @@ CSV.foreach(@csv_file, :headers => true){|row|
         asset_os = nil
         asset_id = nil
 
-
-      
         risk_score = vuln.fetch("risk_meter_score")
         cvss_severity = vuln.fetch("severity")
         cvss_threat = vuln.fetch("threat")
@@ -221,6 +221,8 @@ CSV.foreach(@csv_file, :headers => true){|row|
             asset_url = vuln["urls"].fetch("asset")
             asset_url = "https://#{asset_url}"
             puts "asset url= #{asset_url}" if @debug
+            
+            # Get vulnerability asset information.
             asset_return = RestClient::Request.execute(
               :method => :get,
               :url => asset_url,
@@ -284,6 +286,7 @@ CSV.foreach(@csv_file, :headers => true){|row|
 
         hold_row = []
 
+        # Build a CSV row.
         hold_row += [risk_score,
           cvss_severity,
           cvss_threat,
@@ -356,7 +359,7 @@ CSV.foreach(@csv_file, :headers => true){|row|
   rescue Exception => e
     @output_filename.error("General Exception:...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})")
     puts "BadRequest: #{e.backtrace.inspect}"
-end
+  end
 File.delete (output_results)
 
 

--- a/vulnerability_score_setter/readme.md
+++ b/vulnerability_score_setter/readme.md
@@ -1,21 +1,21 @@
 # Kenna Vulnerability Score Setter
-This script will override Kenna scores for select vulnerabilities
+This script will override Kenna scores for select vulnerabilities.
 
-Usage:
+## Usage:
 
 ```
 score_setter_mt.rb <Kenna API token> <CSV file of score overrides>
 ```
 
-Parameters:
+### Parameters:
  - token = Kenna Application token
  - csv_file = csv file with score overrides
 
-Tested on:
+### Tested on:
 
 - ruby 2.3.0p0 (2015-12-25 revision 53290)
 
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
 - [`rest-client`](https://github.com/rest-client/rest-client)
 - [`json`](http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html)
@@ -23,7 +23,7 @@ Required Ruby classes/gems:
 - [`thread`](https://ruby-doc.org/core-2.2.0/Thread.html)
 - [`monitor`](https://ruby-doc.org/stdlib-2.1.2/libdoc/monitor/rdoc/Monitor.html)
 
-CSV Expected Columns
+### CSV Expected Columns
 
 - Reset_Type = Search param to be used to find rescore items (scanner_id, vulnerability_name, cve, cwe, scanner_id, fix_title_keyword, fix_id, scanner_score)
 - Value = Corresponding value to be pair with search team in Reset_Type

--- a/vulnerability_score_setter/readme.md
+++ b/vulnerability_score_setter/readme.md
@@ -13,7 +13,7 @@ score_setter_mt.rb <Kenna API token> <CSV file of score overrides>
 
 ### Tested on:
 
-- ruby 2.3.0p0 (2015-12-25 revision 53290)
+- ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
 
 ### Required Ruby classes/gems:
 

--- a/vulnerability_score_setter/score_setter_mt.rb
+++ b/vulnerability_score_setter/score_setter_mt.rb
@@ -19,7 +19,7 @@ output_filename = "kenna_score_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}.
 @vuln_api_bulk = 'bulk'
 @search_url = "/search?" 
 @urlquerybit = 'q='
-@bulk_api_url = 'https://api.kennasecurity.com/data_exports'
+@data_exports_api_url = 'https://api.kennasecurity.com/data_exports'
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
 
 @max_retries = 5
@@ -319,7 +319,7 @@ consumer_thread = Thread.new do
           puts bulk_query_json.to_s
           query_response = RestClient::Request.execute(
             :method => :post,
-            :url => @bulk_api_url,
+            :url => @data_exports_api_url,
             :headers => @headers,
             :payload => bulk_query_json_string
           ) 
@@ -331,7 +331,7 @@ consumer_thread = Thread.new do
           searchComplete = false
 
           while searchComplete == false
-            status_code = RestClient.get("https://api.kennasecurity.com/data_exports/status?search_id=#{searchID}", @headers).code
+            status_code = RestClient.get("#{@data_exports_api_url}/status?search_id=#{searchID}", @headers).code
 
             puts "status code =#{status_code}" if @debug
             if status_code != 200 then 
@@ -349,7 +349,7 @@ consumer_thread = Thread.new do
                     f.write chunk
                   end
                 }
-                RestClient::Request.new(:method => :get, :url => "https://api.kennasecurity.com/data_exports?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
+                RestClient::Request.new(:method => :get, :url => "?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
               }
               
               # Open the gzip file and process.

--- a/vulnerability_score_setter/score_setter_mt.rb
+++ b/vulnerability_score_setter/score_setter_mt.rb
@@ -9,15 +9,10 @@ require 'monitor'
 @token = ARGV[0]
 @meta_file = ARGV[1] #list of rescore rules
 
-@enc_colon = "%3A"
-@enc_dblquote = "%22"
-@enc_space = "%20"
-
 start_time = Time.now
 @start_time = start_time
 output_filename = "kenna_score_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}.txt"
 @output_filename = output_filename
-
 
 #Variables we'll need later
 @vuln_api_url = 'https://api.kennasecurity.com/vulnerabilities'
@@ -27,51 +22,50 @@ output_filename = "kenna_score_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}.
 @bulk_api_url = 'https://api.kennasecurity.com/data_exports'
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
 
-
 @max_retries = 5
 @debug = false
 
-
 def post_data(post_url,json_data)
-   begin
+  begin
     #puts "posting url #{post_url}" if @debug
     #puts "posting json #{json_data}" if @debug
-      query_post_return = RestClient::Request.execute(
-        :method => :put,
-        :url => post_url,
-        :payload => json_data,
-        :headers => @headers
-      )
-      rescue RestClient::TooManyRequests =>e
-        retry
-      rescue RestClient::UnprocessableEntity => e
-        puts "unprocessible entity: #{e.message}"
-      rescue RestClient::BadRequest => e
-        log_output = File.open(@output_filename,'a+')
-        log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{e.backtrace.inspect}"
-        Thread.exit
-      rescue RestClient::Exception => e
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          log_output = File.open(@output_filename,'a+')
-          log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "Unable to get vulns: #{e.backtrace.inspect}"
-          Thread.exit
-        end
-      rescue Exception => e
-        log_output = File.open(@output_filename,'a+')
-        log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{e.backtrace.inspect}"
-        Thread.exit
+    query_post_return = RestClient::Request.execute(
+      :method => :put,
+      :url => post_url,
+      :payload => json_data,
+      :headers => @headers
+    )
+  rescue RestClient::TooManyRequests =>e
+    retry
+  rescue RestClient::UnprocessableEntity => e
+    puts "unprocessible entity: #{e.message}"
+  rescue RestClient::BadRequest => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.backtrace.inspect}"
+    Thread.exit
+  rescue RestClient::Exception => e
+    @retries ||= 0
+    if @retries < @max_retries
+      @retries += 1
+      sleep(15)
+      retry
+    else
+      log_output = File.open(@output_filename,'a+')
+      log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output.close
+      puts "Unable to get vulns: #{e.backtrace.inspect}"
+      Thread.exit
     end
+  rescue Exception => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.backtrace.inspect}"
+    Thread.exit
+  end
+  puts JSON.parse(query_post_return.body)
 end
 
 # Set a finite number of simultaneous worker threads that can run
@@ -99,7 +93,7 @@ producer_thread = Thread.new do
   ## Iterate through CSV
   CSV.foreach(@meta_file, :headers => true, :encoding => "UTF-8"){|row|
 
-    current_line = $.
+    #current_line = $.
 
     log_output = File.open(output_filename,'a+')
     log_output << "Reading line #{$.}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
@@ -138,10 +132,9 @@ producer_thread = Thread.new do
       cfdata = ["#{row['Custom_Field_Name']}","#{row['Custom_Field_ID']}","#{row['Custom_Field_Value']}"]
     end
     
-    json_string = nil
-
     json_string = "{\"vulnerability\": {\"override_score\": #{row['New_Score']}}}"
 
+    # Put the row on the work queue
     work_queue << Array[vuln_query,json_string,cfdata]
     
     # Tell the consumer to check the thread array so it can attempt to schedule the
@@ -269,7 +262,7 @@ consumer_thread = Thread.new do
         Thread.exit
       end
 
-      # Put the row on the work queue
+      # Check to see if a data export is needed.
       if pages > 20 then
         async_query = true
       end
@@ -278,7 +271,6 @@ consumer_thread = Thread.new do
       puts "async query needed #{async_query}" if @debug
 
       begin
-
         if async_query then
           query_url = "#{@async_api_url}"
         end
@@ -287,17 +279,17 @@ consumer_thread = Thread.new do
           puts "starting regular query" if @debug
 
           morepages = true
-
           while morepages
             puts "paging url = #{query_url}&page=#{i}" if @debug
 
-            if i>1 then
+            if i > 1 then
               query_response = RestClient::Request.execute(
                 :method => :get,
                 :url => "#{query_url}&page=#{i}",
                 :headers => @headers
               )
             end
+
             # Build URL to set the custom field value for each vulnerability
             query_response_json = JSON.parse(query_response.body)["vulnerabilities"]
             meta_response_json = JSON.parse(query_response.body)["meta"]
@@ -316,7 +308,7 @@ consumer_thread = Thread.new do
         else
           puts "starting async query" if @debug
 
-
+          # Bulk query is invoking Data Export APIs.
           bulk_query_json_string = "{\"asset\": {\"status\": [\"active\"]}, \"status\": [\"open\"], "
 
           if !vuln_query.empty? then
@@ -347,7 +339,6 @@ consumer_thread = Thread.new do
           searchComplete = false
 
           while searchComplete == false
-          
             status_code = RestClient.get("https://api.kennasecurity.com/data_exports/status?search_id=#{searchID}", @headers).code
 
             puts "status code =#{status_code}" if @debug
@@ -358,6 +349,8 @@ consumer_thread = Thread.new do
             else
               puts "ansyc query complete" if @debug
               searchComplete = true
+              
+              # Download the gzip file.
               File.open(output_results, 'w') {|f|
                 block = proc { |response|
                   response.read_body do |chunk| 
@@ -366,6 +359,8 @@ consumer_thread = Thread.new do
                 }
                 RestClient::Request.new(:method => :get, :url => "https://api.kennasecurity.com/data_exports?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
               }
+              
+              # Open the gzip file and process.
               gzfile = open(output_results)
               gz = Zlib::GzipReader.new(gzfile)
               vuln_ids = []
@@ -373,15 +368,12 @@ consumer_thread = Thread.new do
               results_json.each do |item|
                 vuln_ids << item["id"]
               end
-             
             end 
-               
           end
+
           File.delete(output_results)
         end
 
-
-        temp_string = ""   
         post_url = "#{@vuln_api_url}/#{@vuln_api_bulk}"
         puts vuln_ids.size
         count = 0
@@ -395,7 +387,6 @@ consumer_thread = Thread.new do
           puts json_data
           temp_data = temp_data.insert(temp_data.index('vulnerability')-1, "\"vulnerability_ids\": #{a},") 
           post_data(post_url,temp_data)
-
         end 
 
       rescue RestClient::TooManyRequests => e
@@ -450,4 +441,3 @@ threads.each do |thread|
     thread.join unless thread.nil?
 end
 puts "DONE!"
-

--- a/vulnerability_score_setter/score_setter_mt.rb
+++ b/vulnerability_score_setter/score_setter_mt.rb
@@ -86,7 +86,6 @@ threads_available = threads.new_cond
 # Add a variable to tell the consumer that we are done producing work
 sysexit = false
 
-
 producer_thread = Thread.new do
   puts "starting producer loop" if @debug
   
@@ -102,6 +101,7 @@ producer_thread = Thread.new do
     vuln_query = ""
     cfdata = []
 
+    # Process the CSV file columns.
     if !row["Reset_Type"].nil? then
       if row["Reset_Type"] == "vulnerability_name" then
         vuln_query = "#{row['Reset_Type']}:%22#{row['Value']}%22"
@@ -174,8 +174,6 @@ consumer_thread = Thread.new do
                                               thread["finished"].nil? == false }
       puts "i just found index = #{found_index}" if @debug
     end
-    # Get a new unit of work from the work queue
-
 
     threads[found_index] = Thread.new(work_to_do) do
       puts "starting the thread loop" if @debug
@@ -210,7 +208,6 @@ consumer_thread = Thread.new do
       puts "query url = #{query_url}" if @debug
       #puts "json data = #{json_data}" if @debug
 
-
       begin
         query_response = RestClient::Request.execute(
           :method => :get,
@@ -218,7 +215,6 @@ consumer_thread = Thread.new do
           :headers => @headers
         ) 
         
-
       query_meta_json = JSON.parse(query_response)["meta"]
       tot_vulns = query_meta_json.fetch("total_count")
       pages = query_meta_json.fetch("pages")
@@ -271,10 +267,6 @@ consumer_thread = Thread.new do
       puts "async query needed #{async_query}" if @debug
 
       begin
-        if async_query then
-          query_url = "#{@async_api_url}"
-        end
-
         if !async_query then 
           puts "starting regular query" if @debug
 

--- a/vulnerability_status_setter /readme.md
+++ b/vulnerability_status_setter /readme.md
@@ -13,7 +13,7 @@ status_setter_mt.rb <Kenna API token> <CSV file of status overrides>
 
 ### Tested on:
 
-- ruby 2.3.0p0 (2015-12-25 revision 53290)
+- ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.x86_64-darwin22]
 
 ### Required Ruby classes/gems:
 
@@ -28,7 +28,7 @@ status_setter_mt.rb <Kenna API token> <CSV file of status overrides>
 - Reset_Type = Search param to be used to find rescore items (scanner_id, vulnerability_name, cve, cwe, scanner_id, fix_title_keyword, fix_id, scanner_score)
 - Value = Corresponding value to be pair with search team in Reset_Type
 - Current_Status = Vulnerability score to search for before rescore (example 0 to find only new informational items)
-- New_Status = The new static score to be set for each vulnerability found 
+- New_Status = The new status to be set for each vulnerability found 
 - Tags = Comma separated list of tags to be included in search
 - Tag_Operator = AND or OR to be used for items in Tags
 - Set_Due_Date = Due date to add to the changed records

--- a/vulnerability_status_setter /readme.md
+++ b/vulnerability_status_setter /readme.md
@@ -1,21 +1,21 @@
 # Kenna Vulnerability Status Setter
-This script will override Kenna status for select vulnerabilities
+This script will override Kenna status for select vulnerabilities.  If the number of vulnerabilities is over 10,000, then a data export is preformed.
 
-Usage:
+## Usage:
 
 ```
 status_setter_mt.rb <Kenna API token> <CSV file of status overrides>
 ```
 
-Parameters:
+### Parameters:
  - token = Kenna Application token
  - csv_file = csv file with status overrides
 
-Tested on:
+### Tested on:
 
 - ruby 2.3.0p0 (2015-12-25 revision 53290)
 
-Required Ruby classes/gems:
+### Required Ruby classes/gems:
 
 - [`rest-client`](https://github.com/rest-client/rest-client)
 - [`json`](http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html)
@@ -23,7 +23,7 @@ Required Ruby classes/gems:
 - [`thread`](https://ruby-doc.org/core-2.2.0/Thread.html)
 - [`monitor`](https://ruby-doc.org/stdlib-2.1.2/libdoc/monitor/rdoc/Monitor.html)
 
-CSV Expected Columns
+### CSV Expected Columns
 
 - Reset_Type = Search param to be used to find rescore items (scanner_id, vulnerability_name, cve, cwe, scanner_id, fix_title_keyword, fix_id, scanner_score)
 - Value = Corresponding value to be pair with search team in Reset_Type

--- a/vulnerability_status_setter /status_setter_mt.rb
+++ b/vulnerability_status_setter /status_setter_mt.rb
@@ -1,5 +1,7 @@
 #status setter multi-threaded
 require 'rest-client'
+require 'cgi'
+#require 'uri'
 require 'json'
 require 'csv'
 require 'thread'
@@ -25,7 +27,7 @@ output_filename = "kenna_status_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}
 @max_retries = 5
 @debug = false
 
-def post_data(post_url,json_data)
+def post_data(post_url, json_data)
   begin
     query_post_return = RestClient::Request.execute(
       :method => :put,
@@ -36,7 +38,7 @@ def post_data(post_url,json_data)
   rescue RestClient::TooManyRequests =>e
     retry
   rescue RestClient::UnprocessableEntity => e
-    puts "unprocessible entity: #{e.message}"
+    puts "unprocessible entity: #{e.message} for #{post_url}"
   rescue RestClient::BadRequest => e
     log_output = File.open(@output_filename,'a+')
     log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
@@ -207,7 +209,8 @@ consumer_thread = Thread.new do
       query_response = nil
 
       query_url = "#{@vuln_api_url}#{@search_url}"
-      query_url = URI::encode(query_url)
+      #query_url = CGI::escape(query_url)  I don't think we need to do this.
+      #query_url = URI::encode(query_url)
 
       if !cfdata.empty? then
         query_url = "#{query_url}custom_fields:#{cfdata[1]}:#{cfdata[0]}%5B%5D=#{cfdata[2]}"
@@ -402,7 +405,7 @@ consumer_thread = Thread.new do
           puts json_data
           temp_data = temp_data.insert(temp_data.index('vulnerability')-1, "\"vulnerability_ids\": #{a},") 
           puts temp_data
-          post_data(post_url,temp_data)
+          post_data(post_url, temp_data)
 
         end 
 
@@ -412,7 +415,7 @@ consumer_thread = Thread.new do
         log_output = File.open(output_filename,'a+')
         log_output << "UnprocessableEntity: #{query_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
         log_output.close
-        puts "UnprocessableEntity: #{e.message}"
+        puts "UnprocessableEntity: #{e.message} for #{query_url}"
         Thread.exit
       rescue RestClient::BadRequest => e
         log_output = File.open(output_filename,'a+')

--- a/vulnerability_status_setter /status_setter_mt.rb
+++ b/vulnerability_status_setter /status_setter_mt.rb
@@ -18,19 +18,16 @@ start_time = Time.now
 output_filename = "kenna_status_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}.txt"
 @output_filename = output_filename
 
-
 #Variables we'll need later
 @vuln_api_url = 'https://api.kennasecurity.com/vulnerabilities'
 @vuln_api_bulk = 'bulk'
 @search_url = "/search?" 
 @urlquerybit = 'q='
-@bulk_api_url = 'https://api.kennasecurity.com/data_exports'
+@data_exports_url = 'https://api.kennasecurity.com/data_exports'
 @headers = {'content-type' => 'application/json', 'X-Risk-Token' => @token, 'accept' => 'application/json'}
-
 
 @max_retries = 5
 @debug = false
-
 
 def post_data(post_url,json_data)
    begin
@@ -156,6 +153,7 @@ producer_thread = Thread.new do
 
      json_string = "#{json_string}}}"
 
+    # Put the row on the work queue
     work_queue << Array[vuln_query,json_string,cfdata,row['Current_Status']]
     
     # Tell the consumer to check the thread array so it can attempt to schedule the
@@ -239,7 +237,6 @@ consumer_thread = Thread.new do
           :url => query_url,
           :headers => @headers
         ) 
-        
 
       query_meta_json = JSON.parse(query_response)["meta"]
       tot_vulns = query_meta_json.fetch("total_count")
@@ -284,20 +281,17 @@ consumer_thread = Thread.new do
         Thread.exit
       end
 
-      # Put the row on the work queue
+      # Determine if we're going to use "Search Vulnerabilities" API or
+      # an async query via data export APIs.
       if pages > 20 then
         async_query = true
       end
+
       i=1
       vuln_ids = []
       puts "async query needed #{async_query}" if @debug
 
       begin
-
-        if async_query then
-          query_url = "#{@async_api_url}"
-        end
-
         if !async_query then 
           puts "starting regular query" if @debug
 
@@ -329,8 +323,7 @@ consumer_thread = Thread.new do
           end
 
         else
-          puts "starting async query" if @debug
-
+          puts "starting async query (data export)" if @debug
 
           bulk_query_json_string = "{\"asset\": {\"status\": [\"active\"]}, \"status\": [\"#{current_status}\"], "
 
@@ -347,11 +340,11 @@ consumer_thread = Thread.new do
 
           bulk_query_json = JSON.parse(bulk_query_json_string)
 
-          puts "bulk query ***** " + bulk_query_json_string
+          puts "bulk query (Request Data Exports) ***** " + bulk_query_json_string
    
           query_response = RestClient::Request.execute(
             :method => :post,
-            :url => @bulk_api_url,
+            :url => @data_exports_url,
             :headers => @headers,
             :payload => bulk_query_json_string
           ) 
@@ -362,6 +355,7 @@ consumer_thread = Thread.new do
           output_results = "myoutputfile_#{searchID}.gz"
           searchComplete = false
 
+          # Check status for completion of data export.
           while searchComplete == false
           
             status_code = RestClient.get("https://api.kennasecurity.com/data_exports/status?search_id=#{searchID}", @headers).code
@@ -372,8 +366,10 @@ consumer_thread = Thread.new do
               sleep(60)
               next
             else
-              puts "ansyc query complete" if @debug
+              puts "ansyc query (data export) complete" if @debug
               searchComplete = true
+
+              # Download the gzip file.
               File.open(output_results, 'w') {|f|
                 block = proc { |response|
                   response.read_body do |chunk| 
@@ -382,6 +378,8 @@ consumer_thread = Thread.new do
                 }
                 RestClient::Request.new(:method => :get, :url => "https://api.kennasecurity.com/data_exports?search_id=#{searchID}", :headers => @headers, :block_response => block).execute
               }
+              
+              # Open gzip file and process.
               gzfile = open(output_results)
               gz = Zlib::GzipReader.new(gzfile)
               vuln_ids = []
@@ -395,7 +393,6 @@ consumer_thread = Thread.new do
           end
           File.delete(output_results)
         end
-
 
         temp_string = ""   
         post_url = "#{@vuln_api_url}/#{@vuln_api_bulk}"

--- a/vulnerability_status_setter /status_setter_mt.rb
+++ b/vulnerability_status_setter /status_setter_mt.rb
@@ -9,10 +9,6 @@ require 'monitor'
 @token = ARGV[0]
 @meta_file = ARGV[1] #list of status change rules
 
-@enc_colon = "%3A"
-@enc_dblquote = "%22"
-@enc_space = "%20"
-
 start_time = Time.now
 @start_time = start_time
 output_filename = "kenna_status_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}.txt"
@@ -30,45 +26,44 @@ output_filename = "kenna_status_setter_log-#{start_time.strftime("%Y%m%dT%H%M")}
 @debug = false
 
 def post_data(post_url,json_data)
-   begin
-    #puts "posting url #{post_url}" if @debug
-    #puts "posting json #{json_data}" if @debug
-      query_post_return = RestClient::Request.execute(
-        :method => :put,
-        :url => post_url,
-        :payload => json_data,
-        :headers => @headers
-      )
-      rescue RestClient::TooManyRequests =>e
-        retry
-      rescue RestClient::UnprocessableEntity => e
-        puts "unprocessible entity: #{e.message}"
-      rescue RestClient::BadRequest => e
-        log_output = File.open(@output_filename,'a+')
-        log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{e.backtrace.inspect}"
-        Thread.exit
-      rescue RestClient::Exception => e
-        @retries ||= 0
-        if @retries < @max_retries
-          @retries += 1
-          sleep(15)
-          retry
-        else
-          log_output = File.open(@output_filename,'a+')
-          log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-          log_output.close
-          puts "Unable to get vulns: #{e.backtrace.inspect}"
-          Thread.exit
-        end
-      rescue Exception => e
-        log_output = File.open(@output_filename,'a+')
-        log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
-        log_output.close
-        puts "BadRequest: #{e.backtrace.inspect}"
-        Thread.exit
+  begin
+    query_post_return = RestClient::Request.execute(
+      :method => :put,
+      :url => post_url,
+      :payload => json_data,
+      :headers => @headers
+    )
+  rescue RestClient::TooManyRequests =>e
+    retry
+  rescue RestClient::UnprocessableEntity => e
+    puts "unprocessible entity: #{e.message}"
+  rescue RestClient::BadRequest => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.backtrace.inspect}"
+    Thread.exit
+  rescue RestClient::Exception => e
+    @retries ||= 0
+    if @retries < @max_retries
+      @retries += 1
+      sleep(15)
+      retry
+    else
+      log_output = File.open(@output_filename,'a+')
+      log_output << "General RestClient error #{post_url}... #{e.message}(time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+      log_output.close
+      puts "Unable to get vulns: #{e.backtrace.inspect}"
+      Thread.exit
     end
+  rescue Exception => e
+    log_output = File.open(@output_filename,'a+')
+    log_output << "BadRequest: #{post_url}...#{e.message} (time: #{Time.now.to_s}, start time: #{@start_time.to_s})\n"
+    log_output.close
+    puts "BadRequest: #{e.backtrace.inspect}"
+    Thread.exit
+    @output_filename.error("bulk vuln update status: #{JSON.parse(query_post_return.body)}... time: #{Time.now.to_s}\n")
+  end
 end
 
 # Set a finite number of simultaneous worker threads that can run
@@ -96,7 +91,7 @@ producer_thread = Thread.new do
   ## Iterate through CSV
   CSV.foreach(@meta_file, :headers => true, :encoding => "UTF-8"){|row|
 
-    current_line = $.
+    #current_line = $.
 
     log_output = File.open(output_filename,'a+')
     log_output << "Reading line #{$.}... (time: #{Time.now.to_s}, start time: #{start_time.to_s})\n"
@@ -338,8 +333,6 @@ consumer_thread = Thread.new do
           bulk_query_json_string = bulk_query_json_string + "\"export_settings\": { \"format\": \"json\", "
           bulk_query_json_string = bulk_query_json_string + "\"compression\": \"gzip\", \"model\": \"vulnerability\" }}"
 
-          bulk_query_json = JSON.parse(bulk_query_json_string)
-
           puts "bulk query (Request Data Exports) ***** " + bulk_query_json_string
    
           query_response = RestClient::Request.execute(
@@ -394,7 +387,6 @@ consumer_thread = Thread.new do
           File.delete(output_results)
         end
 
-        temp_string = ""   
         post_url = "#{@vuln_api_url}/#{@vuln_api_bulk}"
         puts vuln_ids.size
         count = 0


### PR DESCRIPTION
This is the first of two check-ins.  This is one modified some variable names and added comments for clarity. Fixed lint errors.  The next one will remove aysnc query API invokes.  The code in this check-in used `async` to mean invoking the data_export APIs.